### PR TITLE
feat: implement spectator mode (#127)

### DIFF
--- a/backend/app/api/routes/game.py
+++ b/backend/app/api/routes/game.py
@@ -35,6 +35,9 @@ _active_broadcasters: Set[str] = set()
 # Track which sessions came from lobbies (don't auto-cleanup on disconnect)
 _lobby_sessions: Set[str] = set()
 
+# Spectator connections (session_id -> set of WebSockets)
+_spectator_connections: Dict[str, Set[WebSocket]] = {}
+
 
 class ConnectionManager:
     """Manages WebSocket connections for multiplayer games."""
@@ -170,12 +173,16 @@ def get_or_create_session(session_id: Optional[str] = None, difficulty: str = "m
 
 
 async def broadcast_game_state(session_id: str) -> None:
-    """Broadcast current game state to all players in a session."""
+    """Broadcast current game state to all players and spectators in a session."""
     if session_id not in _game_sessions:
         return
 
     engine = _game_sessions[session_id]
     state = engine.get_state_snapshot()
+
+    # Inject spectator count
+    spectator_count = len(_spectator_connections.get(session_id, set()))
+    state['spectator_count'] = spectator_count
 
     message = {
         'type': 'game_state',
@@ -183,6 +190,20 @@ async def broadcast_game_state(session_id: str) -> None:
     }
 
     await manager.broadcast(message, session_id)
+
+    # Also broadcast to spectators
+    if session_id in _spectator_connections:
+        json_message = json.dumps(message)
+        disconnected = []
+        for ws in list(_spectator_connections[session_id]):
+            try:
+                await ws.send_text(json_message)
+            except Exception:
+                disconnected.append(ws)
+        for ws in disconnected:
+            _spectator_connections[session_id].discard(ws)
+            if not _spectator_connections[session_id]:
+                del _spectator_connections[session_id]
 
 
 async def state_broadcaster(session_id: str, update_rate: int = 60) -> None:
@@ -273,7 +294,7 @@ async def heartbeat_monitor(
 
 async def broadcast_to_lobby(lobby_id: str, message: dict, exclude_player_id: Optional[str] = None) -> None:
     """
-    Broadcast a message to all members of a lobby.
+    Broadcast a message to all members and spectators of a lobby.
 
     Args:
         lobby_id: Lobby identifier
@@ -292,6 +313,13 @@ async def broadcast_to_lobby(lobby_id: str, message: dict, exclude_player_id: Op
             continue
 
         await manager.send_to_player(member.player_id, message)
+
+    # Send to all spectators
+    for spectator in lobby.spectators.values():
+        if exclude_player_id and spectator.player_id == exclude_player_id:
+            continue
+
+        await manager.send_to_player(spectator.player_id, message)
 
 
 def serialize_lobby_state(lobby) -> dict:
@@ -326,7 +354,8 @@ def serialize_lobby_state(lobby) -> dict:
             }
             for member in lobby.members.values()
         ],
-        'game_session_id': lobby.game_session_id
+        'game_session_id': lobby.game_session_id,
+        'spectator_count': lobby.get_spectator_count()
     }
 
 
@@ -560,6 +589,67 @@ async def handle_add_bot_to_lobby(lobby_id: str, player_id: str, bot_id: int, we
         db.close()
 
 
+async def handle_spectate_lobby(lobby_id: str, player_id: str, username: Optional[str], websocket: WebSocket) -> None:
+    """
+    Handle spectator joining a lobby via WebSocket.
+
+    Args:
+        lobby_id: Lobby to spectate
+        player_id: Spectator identifier
+        username: Optional spectator username
+        websocket: WebSocket connection
+    """
+    lobby_manager = get_lobby_manager()
+
+    # Join as spectator
+    success = lobby_manager.spectate_lobby(lobby_id, player_id, username)
+
+    if not success:
+        await websocket.send_json({
+            'type': 'error',
+            'data': {'message': 'Failed to spectate lobby (not found or wrong status)'}
+        })
+        return
+
+    # Get lobby state
+    lobby = lobby_manager.get_lobby(lobby_id)
+
+    # Send spectator joined confirmation
+    await websocket.send_json({
+        'type': 'spectator_joined',
+        'data': {
+            'player_id': player_id,
+            'lobby': serialize_lobby_state(lobby)
+        }
+    })
+
+    # Broadcast updated lobby state to other members and spectators
+    await broadcast_to_lobby(lobby_id, {
+        'type': 'lobby_state',
+        'data': serialize_lobby_state(lobby)
+    }, exclude_player_id=player_id)
+
+
+async def handle_leave_spectate(lobby_id: str, player_id: str) -> None:
+    """
+    Handle spectator leaving a lobby.
+
+    Args:
+        lobby_id: Lobby to leave
+        player_id: Spectator identifier
+    """
+    lobby_manager = get_lobby_manager()
+    lobby_manager.remove_spectator(lobby_id, player_id)
+
+    # Broadcast updated state
+    lobby = lobby_manager.get_lobby(lobby_id)
+    if lobby:
+        await broadcast_to_lobby(lobby_id, {
+            'type': 'lobby_state',
+            'data': serialize_lobby_state(lobby)
+        })
+
+
 @router.websocket("/ws")
 async def game_websocket(
     websocket: WebSocket,
@@ -567,7 +657,8 @@ async def game_websocket(
     session_id: Optional[str] = Query(default=None),
     player_id: Optional[str] = Query(default=None),
     difficulty: str = Query(default="medium"),
-    seed: Optional[int] = Query(default=None)
+    seed: Optional[int] = Query(default=None),
+    spectate: bool = Query(default=False)
 ):
     """
     WebSocket endpoint for real-time multiplayer racing.
@@ -602,18 +693,145 @@ async def game_websocket(
 
     # Determine connection mode
     is_lobby_mode = lobby_id is not None
+    is_spectator = spectate
 
     if is_lobby_mode:
-        # Lobby mode - don't create session yet, wait for lobby to start race
-        # Connect without session_id (will be set when race starts)
+        # Connect to lobby WebSocket
         await manager.connect(websocket, lobby_id, player_id)
 
-        # Join lobby (use player_id as username since we passed it in)
-        await handle_join_lobby(lobby_id, player_id, player_id, websocket)
+        if is_spectator:
+            # Spectator mode - join as spectator
+            await handle_spectate_lobby(lobby_id, player_id, player_id, websocket)
+
+            # If lobby is already racing, send track data and connect to game session
+            lobby_manager = get_lobby_manager()
+            lobby = lobby_manager.get_lobby(lobby_id)
+            if lobby and lobby.status == LobbyStatus.RACING and lobby.game_session_id:
+                game_sid = lobby.game_session_id
+                if game_sid in _game_sessions:
+                    engine_for_track = _game_sessions[game_sid]
+                    track = engine_for_track.state.track
+                    await websocket.send_json({
+                        'type': 'race_starting',
+                        'data': {
+                            'game_session_id': game_sid,
+                            'track': {
+                                'segments': [
+                                    {
+                                        'start': {
+                                            'x': seg.start.x,
+                                            'y': seg.start.y,
+                                            'width': seg.start.width,
+                                            'surface': seg.start.surface.value if hasattr(seg.start.surface, 'value') else seg.start.surface
+                                        },
+                                        'end': {
+                                            'x': seg.end.x,
+                                            'y': seg.end.y,
+                                            'width': seg.end.width,
+                                            'surface': seg.end.surface.value if hasattr(seg.end.surface, 'value') else seg.end.surface
+                                        },
+                                        'control1': list(seg.control1) if seg.control1 else None,
+                                        'control2': list(seg.control2) if seg.control2 else None,
+                                    }
+                                    for seg in track.segments
+                                ],
+                                'checkpoints': [
+                                    {
+                                        'position': list(cp.position),
+                                        'angle': cp.angle,
+                                        'width': cp.width
+                                    }
+                                    for cp in track.checkpoints
+                                ],
+                                'start_position': list(track.start_position),
+                                'start_heading': track.start_heading,
+                                'obstacles': [
+                                    {
+                                        'position': list(obs.position),
+                                        'radius': obs.radius,
+                                        'type': obs.type
+                                    }
+                                    for obs in (track.obstacles or [])
+                                ],
+                                'containment': {
+                                    'left_points': [list(p) for p in track.containment.left_points],
+                                    'right_points': [list(p) for p in track.containment.right_points]
+                                } if track.containment else None
+                            }
+                        }
+                    })
+        else:
+            # Regular player mode - join lobby as member
+            await handle_join_lobby(lobby_id, player_id, player_id, websocket)
 
         # Note: Session will be created when host starts race
         session_id = None
         engine = None
+    elif is_spectator and session_id:
+        # Direct spectate mode - spectate an existing game session
+        await websocket.accept()
+
+        # Add to spectator connections
+        if session_id not in _spectator_connections:
+            _spectator_connections[session_id] = set()
+        _spectator_connections[session_id].add(websocket)
+
+        # Send connected message with track data
+        if session_id in _game_sessions:
+            engine = _game_sessions[session_id]
+            track = engine.state.track
+            await websocket.send_json({
+                'type': 'connected',
+                'data': {
+                    'session_id': session_id,
+                    'player_id': player_id,
+                    'track': {
+                        'segments': [
+                            {
+                                'start': {
+                                    'x': seg.start.x,
+                                    'y': seg.start.y,
+                                    'width': seg.start.width,
+                                    'surface': seg.start.surface.value if hasattr(seg.start.surface, 'value') else seg.start.surface
+                                },
+                                'end': {
+                                    'x': seg.end.x,
+                                    'y': seg.end.y,
+                                    'width': seg.end.width,
+                                    'surface': seg.end.surface.value if hasattr(seg.end.surface, 'value') else seg.end.surface
+                                },
+                                'control1': list(seg.control1) if seg.control1 else None,
+                                'control2': list(seg.control2) if seg.control2 else None,
+                            }
+                            for seg in track.segments
+                        ],
+                        'checkpoints': [
+                            {
+                                'position': list(cp.position),
+                                'angle': cp.angle,
+                                'width': cp.width
+                            }
+                            for cp in track.checkpoints
+                        ],
+                        'start_position': list(track.start_position),
+                        'start_heading': track.start_heading,
+                        'obstacles': [
+                            {
+                                'position': list(obs.position),
+                                'radius': obs.radius,
+                                'type': obs.type
+                            }
+                            for obs in (track.obstacles or [])
+                        ],
+                        'containment': {
+                            'left_points': [list(p) for p in track.containment.left_points],
+                            'right_points': [list(p) for p in track.containment.right_points]
+                        } if track.containment else None
+                    }
+                }
+            })
+
+        engine = None  # Spectators don't have engine access
     else:
         # Direct mode (legacy) - create/join session immediately
         session_id, engine = get_or_create_session(session_id, difficulty, seed)
@@ -621,8 +839,8 @@ async def game_websocket(
         # Connect player
         await manager.connect(websocket, session_id, player_id)
 
-    # Start game loop and send initial messages (direct mode only)
-    if not is_lobby_mode:
+    # Start game loop and send initial messages (direct mode only, not spectators)
+    if not is_lobby_mode and not is_spectator:
         if not engine._running:
             await engine.start_loop()
 
@@ -705,6 +923,16 @@ async def game_websocket(
             # Receive message from client
             data = await websocket.receive_text()
             message = json.loads(data)
+
+            # Spectators can only send pong and leave messages
+            if is_spectator:
+                if message['type'] == 'pong':
+                    manager.update_pong_time(websocket)
+                elif message['type'] == 'leave_lobby' and is_lobby_mode:
+                    await handle_leave_spectate(lobby_id, player_id)
+                    break
+                # All other messages (input, start_race, etc.) are silently ignored
+                continue
 
             # Lobby-specific messages
             if message['type'] == 'leave_lobby':
@@ -809,8 +1037,19 @@ async def game_websocket(
                     db.close()
 
     except (WebSocketDisconnect, Exception) as e:
-        # Player disconnected or connection error
-        if is_lobby_mode:
+        # Handle disconnect cleanup
+        if is_spectator:
+            # Spectator disconnect
+            if is_lobby_mode:
+                manager.disconnect(websocket, lobby_id)
+                await handle_leave_spectate(lobby_id, player_id)
+            else:
+                # Direct spectate - remove from spectator connections
+                if session_id in _spectator_connections:
+                    _spectator_connections[session_id].discard(websocket)
+                    if not _spectator_connections[session_id]:
+                        del _spectator_connections[session_id]
+        elif is_lobby_mode:
             # Lobby mode - handle leave and cleanup
             manager.disconnect(websocket, lobby_id)
             await handle_leave_lobby(lobby_id, player_id)

--- a/backend/app/api/routes/lobbies.py
+++ b/backend/app/api/routes/lobbies.py
@@ -68,6 +68,7 @@ class LobbyResponse(BaseModel):
     status: str
     created_at: float
     game_session_id: Optional[str] = None
+    spectator_count: int = 0
 
 
 class LobbyListItemResponse(BaseModel):
@@ -80,6 +81,8 @@ class LobbyListItemResponse(BaseModel):
     max_players: int
     status: str
     created_at: float
+    spectator_count: int = 0
+    game_session_id: Optional[str] = None
 
 
 # ===== Helper Functions =====
@@ -109,7 +112,8 @@ def _lobby_to_response(lobby) -> LobbyResponse:
         ],
         status=lobby.status.value,
         created_at=lobby.created_at,
-        game_session_id=lobby.game_session_id
+        game_session_id=lobby.game_session_id,
+        spectator_count=lobby.get_spectator_count()
     )
 
 
@@ -123,7 +127,9 @@ def _lobby_to_list_item(lobby) -> LobbyListItemResponse:
         member_count=lobby.get_member_count(),
         max_players=lobby.settings.max_players,
         status=lobby.status.value,
-        created_at=lobby.created_at
+        created_at=lobby.created_at,
+        spectator_count=lobby.get_spectator_count(),
+        game_session_id=lobby.game_session_id
     )
 
 

--- a/backend/app/core/lobby.py
+++ b/backend/app/core/lobby.py
@@ -51,6 +51,7 @@ class Lobby:
     host_player_id: str  # Player who created lobby
     settings: LobbySettings
     members: Dict[str, LobbyMember]  # player_id -> LobbyMember
+    spectators: Dict[str, LobbyMember] = field(default_factory=dict)  # player_id -> LobbyMember
     status: LobbyStatus = LobbyStatus.WAITING
     created_at: float = field(default_factory=time.time)
 
@@ -61,8 +62,12 @@ class Lobby:
     track: Optional['Track'] = None  # Forward reference to avoid circular import
 
     def get_member_count(self) -> int:
-        """Get number of members in lobby."""
+        """Get number of members in lobby (excludes spectators)."""
         return len(self.members)
+
+    def get_spectator_count(self) -> int:
+        """Get number of spectators in lobby."""
+        return len(self.spectators)
 
     def is_host(self, player_id: str) -> bool:
         """Check if player is the lobby host."""

--- a/backend/app/core/lobby_manager.py
+++ b/backend/app/core/lobby_manager.py
@@ -196,6 +196,67 @@ class LobbyManager:
 
         return True
 
+    def spectate_lobby(
+        self,
+        lobby_id: str,
+        player_id: str,
+        username: Optional[str] = None
+    ) -> bool:
+        """
+        Add spectator to lobby.
+
+        Spectators can join lobbies in WAITING, STARTING, or RACING status.
+        They receive state broadcasts but cannot send inputs or affect the race.
+
+        Args:
+            lobby_id: Lobby to spectate
+            player_id: Spectator identifier
+            username: Optional display name
+
+        Returns:
+            True if successful, False otherwise
+        """
+        lobby = self._lobbies.get(lobby_id)
+        if not lobby:
+            logger.warning(f"Spectator {player_id} tried to spectate non-existent lobby {lobby_id}")
+            return False
+
+        if lobby.status in (LobbyStatus.FINISHED, LobbyStatus.DISBANDED):
+            logger.warning(f"Spectator {player_id} tried to spectate lobby {lobby_id} in status {lobby.status}")
+            return False
+
+        if player_id in lobby.spectators:
+            logger.debug(f"Spectator {player_id} already spectating lobby {lobby_id}")
+            return True  # Already spectating
+
+        lobby.spectators[player_id] = LobbyMember(
+            player_id=player_id,
+            username=username
+        )
+        logger.info(f"Spectator {player_id} joined lobby {lobby_id} ({lobby.get_spectator_count()} spectators)")
+        return True
+
+    def remove_spectator(self, lobby_id: str, player_id: str) -> bool:
+        """
+        Remove spectator from lobby.
+
+        Does not trigger host transfer or lobby disband.
+
+        Args:
+            lobby_id: Lobby to leave
+            player_id: Spectator identifier
+
+        Returns:
+            True if successful, False otherwise
+        """
+        lobby = self._lobbies.get(lobby_id)
+        if not lobby or player_id not in lobby.spectators:
+            return False
+
+        del lobby.spectators[player_id]
+        logger.info(f"Spectator {player_id} left lobby {lobby_id} ({lobby.get_spectator_count()} spectators remaining)")
+        return True
+
     def add_bot_to_lobby(
         self,
         lobby_id: str,

--- a/backend/tests/test_spectator.py
+++ b/backend/tests/test_spectator.py
@@ -1,0 +1,220 @@
+"""
+Unit tests for spectator mode (issue #127).
+
+Tests spectator joining, lobby spectator tracking, spectator count,
+and ensuring spectators don't affect game state.
+"""
+
+import pytest
+from app.core.lobby import Lobby, LobbyStatus, LobbySettings, LobbyMember
+from app.core.lobby_manager import LobbyManager
+
+
+class TestLobbySpectatorDataStructures:
+    """Test spectator-related fields and methods on Lobby dataclass."""
+
+    def _make_lobby(self, **kwargs) -> Lobby:
+        """Helper to create a lobby with defaults."""
+        defaults = {
+            'lobby_id': 'lobby1',
+            'join_code': 'TEST-CODE-01',
+            'name': 'Test Lobby',
+            'host_player_id': 'host',
+            'settings': LobbySettings(),
+            'members': {
+                'host': LobbyMember(player_id='host', ready=True)
+            },
+        }
+        defaults.update(kwargs)
+        return Lobby(**defaults)
+
+    def test_lobby_has_spectators_dict(self):
+        """Test that Lobby has a spectators dict, defaulting to empty."""
+        lobby = self._make_lobby()
+        assert hasattr(lobby, 'spectators')
+        assert isinstance(lobby.spectators, dict)
+        assert len(lobby.spectators) == 0
+
+    def test_spectator_count_empty(self):
+        """Test get_spectator_count returns 0 when no spectators."""
+        lobby = self._make_lobby()
+        assert lobby.get_spectator_count() == 0
+
+    def test_spectator_count_with_spectators(self):
+        """Test get_spectator_count returns correct count."""
+        lobby = self._make_lobby()
+        lobby.spectators['spec1'] = LobbyMember(player_id='spec1')
+        lobby.spectators['spec2'] = LobbyMember(player_id='spec2')
+        assert lobby.get_spectator_count() == 2
+
+    def test_spectators_not_counted_in_member_count(self):
+        """Test that spectators don't affect get_member_count."""
+        lobby = self._make_lobby()
+        lobby.spectators['spec1'] = LobbyMember(player_id='spec1')
+        assert lobby.get_member_count() == 1  # Only the host
+
+    def test_spectators_not_counted_in_is_full(self):
+        """Test that spectators don't affect is_full check."""
+        lobby = self._make_lobby(
+            settings=LobbySettings(max_players=2)
+        )
+        lobby.members['player2'] = LobbyMember(player_id='player2')
+        # Lobby is full (2/2 members)
+        assert lobby.is_full() is True
+        # Adding spectators shouldn't change that
+        lobby.spectators['spec1'] = LobbyMember(player_id='spec1')
+        assert lobby.is_full() is True
+
+    def test_spectators_dont_affect_can_start_race(self):
+        """Test that spectators don't affect can_start_race."""
+        lobby = self._make_lobby()
+        assert lobby.can_start_race() is True
+        # Adding spectators shouldn't change result
+        lobby.spectators['spec1'] = LobbyMember(player_id='spec1')
+        assert lobby.can_start_race() is True
+
+    def test_spectators_not_affected_by_host_transfer(self):
+        """Test that transfer_host only considers members, not spectators."""
+        lobby = self._make_lobby()
+        lobby.members['player2'] = LobbyMember(player_id='player2')
+        lobby.spectators['spec1'] = LobbyMember(player_id='spec1')
+        # Remove host from members
+        del lobby.members['host']
+        lobby.transfer_host()
+        assert lobby.host_player_id == 'player2'  # Not spec1
+
+
+class TestLobbyManagerSpectators:
+    """Test LobbyManager spectator methods."""
+
+    def setup_method(self):
+        """Create fresh LobbyManager for each test."""
+        self.manager = LobbyManager()
+
+    def _create_lobby(self, **kwargs) -> Lobby:
+        """Helper to create a lobby via the manager."""
+        defaults = {
+            'name': 'Test Lobby',
+            'host_player_id': 'host',
+        }
+        defaults.update(kwargs)
+        return self.manager.create_lobby(**defaults)
+
+    def test_spectate_waiting_lobby(self):
+        """Test spectator can join a WAITING lobby."""
+        lobby = self._create_lobby()
+        result = self.manager.spectate_lobby(lobby.lobby_id, 'spec1', 'Spectator1')
+        assert result is True
+        assert 'spec1' in lobby.spectators
+        assert lobby.spectators['spec1'].username == 'Spectator1'
+
+    def test_spectate_racing_lobby(self):
+        """Test spectator can join a RACING lobby."""
+        lobby = self._create_lobby()
+        lobby.status = LobbyStatus.RACING
+        result = self.manager.spectate_lobby(lobby.lobby_id, 'spec1')
+        assert result is True
+        assert 'spec1' in lobby.spectators
+
+    def test_spectate_starting_lobby(self):
+        """Test spectator can join a STARTING lobby."""
+        lobby = self._create_lobby()
+        lobby.status = LobbyStatus.STARTING
+        result = self.manager.spectate_lobby(lobby.lobby_id, 'spec1')
+        assert result is True
+        assert 'spec1' in lobby.spectators
+
+    def test_spectate_finished_lobby_rejected(self):
+        """Test spectator cannot join a FINISHED lobby."""
+        lobby = self._create_lobby()
+        lobby.status = LobbyStatus.FINISHED
+        result = self.manager.spectate_lobby(lobby.lobby_id, 'spec1')
+        assert result is False
+        assert 'spec1' not in lobby.spectators
+
+    def test_spectate_disbanded_lobby_rejected(self):
+        """Test spectator cannot join a DISBANDED lobby."""
+        lobby = self._create_lobby()
+        lobby.status = LobbyStatus.DISBANDED
+        result = self.manager.spectate_lobby(lobby.lobby_id, 'spec1')
+        assert result is False
+
+    def test_spectate_nonexistent_lobby(self):
+        """Test spectating a nonexistent lobby returns False."""
+        result = self.manager.spectate_lobby('nonexistent', 'spec1')
+        assert result is False
+
+    def test_spectator_already_spectating(self):
+        """Test that spectating again returns True (idempotent)."""
+        lobby = self._create_lobby()
+        self.manager.spectate_lobby(lobby.lobby_id, 'spec1')
+        result = self.manager.spectate_lobby(lobby.lobby_id, 'spec1')
+        assert result is True
+        assert lobby.get_spectator_count() == 1
+
+    def test_remove_spectator(self):
+        """Test removing a spectator from lobby."""
+        lobby = self._create_lobby()
+        self.manager.spectate_lobby(lobby.lobby_id, 'spec1')
+        assert lobby.get_spectator_count() == 1
+
+        result = self.manager.remove_spectator(lobby.lobby_id, 'spec1')
+        assert result is True
+        assert lobby.get_spectator_count() == 0
+
+    def test_remove_spectator_not_found(self):
+        """Test removing a spectator that doesn't exist."""
+        lobby = self._create_lobby()
+        result = self.manager.remove_spectator(lobby.lobby_id, 'spec1')
+        assert result is False
+
+    def test_remove_spectator_nonexistent_lobby(self):
+        """Test removing spectator from nonexistent lobby."""
+        result = self.manager.remove_spectator('nonexistent', 'spec1')
+        assert result is False
+
+    def test_spectator_leave_does_not_transfer_host(self):
+        """Test that spectator leaving doesn't trigger host transfer."""
+        lobby = self._create_lobby()
+        self.manager.spectate_lobby(lobby.lobby_id, 'spec1')
+        self.manager.remove_spectator(lobby.lobby_id, 'spec1')
+        assert lobby.host_player_id == 'host'
+        assert lobby.status == LobbyStatus.WAITING
+
+    def test_spectator_leave_does_not_disband(self):
+        """Test that spectator leaving doesn't disband the lobby."""
+        lobby = self._create_lobby()
+        self.manager.spectate_lobby(lobby.lobby_id, 'spec1')
+        self.manager.remove_spectator(lobby.lobby_id, 'spec1')
+        # Lobby should still exist with its host
+        assert self.manager.get_lobby(lobby.lobby_id) is not None
+        assert lobby.status == LobbyStatus.WAITING
+
+    def test_spectator_not_added_as_member(self):
+        """Test that spectating does not add to members dict."""
+        lobby = self._create_lobby()
+        self.manager.spectate_lobby(lobby.lobby_id, 'spec1')
+        assert 'spec1' not in lobby.members
+        assert lobby.get_member_count() == 1  # Only host
+
+    def test_multiple_spectators(self):
+        """Test multiple spectators can join."""
+        lobby = self._create_lobby()
+        for i in range(10):
+            result = self.manager.spectate_lobby(lobby.lobby_id, f'spec{i}')
+            assert result is True
+        assert lobby.get_spectator_count() == 10
+        # Members count unaffected
+        assert lobby.get_member_count() == 1
+
+    def test_spectator_does_not_fill_lobby(self):
+        """Test that spectators don't count toward max_players."""
+        lobby = self._create_lobby(settings=LobbySettings(max_players=2))
+        # Add spectators
+        for i in range(5):
+            self.manager.spectate_lobby(lobby.lobby_id, f'spec{i}')
+        # Lobby should not be full (only 1 member)
+        assert lobby.is_full() is False
+        # Can still add a real player
+        result = self.manager.join_lobby(lobby.lobby_id, 'player2')
+        assert result is True

--- a/backend/tests/test_spectator_ws.py
+++ b/backend/tests/test_spectator_ws.py
@@ -1,0 +1,183 @@
+"""
+Integration tests for spectator WebSocket endpoint (issue #127).
+
+Tests the full WS connection flow for spectators:
+- Connecting with spectate=true to a waiting lobby
+- Connecting to a non-existent lobby
+- Inputs are silently ignored for spectators
+- Disconnecting removes spectator from lobby
+
+Unit-level spectator data-structure tests live in test_spectator.py;
+this file covers the WebSocket endpoint integration.
+"""
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+from app.core.lobby_manager import get_lobby_manager
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_lobby_manager():
+    manager = get_lobby_manager()
+    manager._lobbies.clear()
+    yield
+    manager._lobbies.clear()
+
+
+def _create_waiting_lobby(client: TestClient, host: str = "host1", name: str = "Test Lobby") -> str:
+    """Helper: create a lobby via REST and return its id."""
+    response = client.post("/lobbies", json={"name": name, "host_player_id": host})
+    assert response.status_code == 201, response.text
+    return response.json()["lobby_id"]
+
+
+class TestSpectatorWebSocketJoin:
+    """Spectator joining a lobby via WS."""
+
+    def test_spectator_connects_to_waiting_lobby(self, client):
+        """Spectator connecting to a WAITING lobby receives spectator_joined."""
+        lobby_id = _create_waiting_lobby(client)
+
+        with client.websocket_connect(
+            f"/game/ws?lobby_id={lobby_id}&player_id=spec1&spectate=true"
+        ) as ws:
+            message = ws.receive_json()
+            assert message["type"] == "spectator_joined"
+            assert message["data"]["player_id"] == "spec1"
+            lobby_state = message["data"]["lobby"]
+            assert lobby_state["lobby_id"] == lobby_id
+            assert lobby_state["spectator_count"] == 1
+
+        # After disconnect, spectator should be cleaned up
+        manager = get_lobby_manager()
+        lobby = manager.get_lobby(lobby_id)
+        assert lobby is not None
+        assert lobby.get_spectator_count() == 0
+
+    def test_spectator_added_to_lobby_state(self, client):
+        """Lobby reflects the spectator while connected."""
+        lobby_id = _create_waiting_lobby(client)
+
+        with client.websocket_connect(
+            f"/game/ws?lobby_id={lobby_id}&player_id=spec1&spectate=true"
+        ) as ws:
+            ws.receive_json()  # spectator_joined
+
+            manager = get_lobby_manager()
+            lobby = manager.get_lobby(lobby_id)
+            assert lobby.get_spectator_count() == 1
+            assert "spec1" in lobby.spectators
+            # Spectator must not be in members
+            assert "spec1" not in lobby.members
+            assert lobby.get_member_count() == 1  # Only the host
+
+    def test_multiple_spectators_share_lobby(self, client):
+        """Two spectators connecting are both tracked."""
+        lobby_id = _create_waiting_lobby(client)
+
+        with client.websocket_connect(
+            f"/game/ws?lobby_id={lobby_id}&player_id=spec1&spectate=true"
+        ) as ws1:
+            ws1.receive_json()  # spectator_joined for spec1
+            with client.websocket_connect(
+                f"/game/ws?lobby_id={lobby_id}&player_id=spec2&spectate=true"
+            ) as ws2:
+                ws2.receive_json()  # spectator_joined for spec2
+
+                manager = get_lobby_manager()
+                lobby = manager.get_lobby(lobby_id)
+                assert lobby.get_spectator_count() == 2
+                assert "spec1" in lobby.spectators
+                assert "spec2" in lobby.spectators
+
+
+class TestSpectatorWebSocketErrors:
+    """Spectator endpoint error paths."""
+
+    def test_spectator_on_nonexistent_lobby_receives_error(self, client):
+        """Spectating a lobby that doesn't exist returns an error message."""
+        with client.websocket_connect(
+            "/game/ws?lobby_id=does-not-exist&player_id=spec1&spectate=true"
+        ) as ws:
+            message = ws.receive_json()
+            assert message["type"] == "error"
+            assert "lobby" in message["data"]["message"].lower()
+
+
+class TestSpectatorWebSocketInputs:
+    """Spectator-side message handling rules."""
+
+    def test_spectator_input_is_silently_ignored(self, client):
+        """A spectator sending an 'input' message does not raise or affect state."""
+        lobby_id = _create_waiting_lobby(client)
+
+        with client.websocket_connect(
+            f"/game/ws?lobby_id={lobby_id}&player_id=spec1&spectate=true"
+        ) as ws:
+            ws.receive_json()  # spectator_joined
+
+            # Send an input message — should be silently ignored
+            ws.send_text(json.dumps({
+                "type": "input",
+                "data": {
+                    "accelerate": True,
+                    "brake": False,
+                    "turn_left": False,
+                    "turn_right": False,
+                    "nitro": False,
+                },
+            }))
+
+            # The connection must still be alive — confirm by sending a pong
+            ws.send_text(json.dumps({"type": "pong"}))
+
+            # Spectator is still in the lobby
+            manager = get_lobby_manager()
+            lobby = manager.get_lobby(lobby_id)
+            assert lobby.get_spectator_count() == 1
+
+
+class TestSpectatorWebSocketDisconnect:
+    """Spectator cleanup on disconnect."""
+
+    def test_disconnect_removes_spectator_from_lobby(self, client):
+        """Closing the WS removes the spectator from the lobby spectators dict."""
+        lobby_id = _create_waiting_lobby(client)
+
+        with client.websocket_connect(
+            f"/game/ws?lobby_id={lobby_id}&player_id=spec1&spectate=true"
+        ) as ws:
+            ws.receive_json()  # spectator_joined
+            manager = get_lobby_manager()
+            assert manager.get_lobby(lobby_id).get_spectator_count() == 1
+
+        # After context exit (disconnect), spectator must be gone
+        manager = get_lobby_manager()
+        lobby = manager.get_lobby(lobby_id)
+        assert lobby is not None
+        assert lobby.get_spectator_count() == 0
+        assert "spec1" not in lobby.spectators
+
+    def test_explicit_leave_lobby_removes_spectator(self, client):
+        """Sending leave_lobby breaks the loop and cleans up."""
+        lobby_id = _create_waiting_lobby(client)
+
+        with client.websocket_connect(
+            f"/game/ws?lobby_id={lobby_id}&player_id=spec1&spectate=true"
+        ) as ws:
+            ws.receive_json()  # spectator_joined
+            ws.send_text(json.dumps({"type": "leave_lobby"}))
+
+        manager = get_lobby_manager()
+        lobby = manager.get_lobby(lobby_id)
+        assert lobby is not None
+        assert lobby.get_spectator_count() == 0

--- a/frontend/src/game/GameCanvas.tsx
+++ b/frontend/src/game/GameCanvas.tsx
@@ -11,12 +11,18 @@ interface GameCanvasProps {
   gameState: GameState | null;
   width?: number;
   height?: number;
+  isSpectator?: boolean;
+  spectatorTarget?: string | null;
+  cameraMode?: 'follow' | 'free';
 }
 
 export const GameCanvas: React.FC<GameCanvasProps> = ({
   gameState,
   width = 800,
-  height = 600
+  height = 600,
+  isSpectator = false,
+  spectatorTarget = null,
+  cameraMode = 'follow',
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const cameraRef = useRef<Camera>(new Camera());
@@ -24,6 +30,36 @@ export const GameCanvas: React.FC<GameCanvasProps> = ({
   const [fps, setFps] = useState<number>(0);
   const frameCountRef = useRef<number>(0);
   const lastFpsUpdateRef = useRef<number>(Date.now());
+
+  // Free camera state for spectators
+  const freeCamKeysRef = useRef<{ w: boolean; a: boolean; s: boolean; d: boolean }>({
+    w: false, a: false, s: false, d: false,
+  });
+
+  // Free camera keyboard handler
+  useEffect(() => {
+    if (!isSpectator || cameraMode !== 'free') return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      if (key in freeCamKeysRef.current) {
+        freeCamKeysRef.current[key as keyof typeof freeCamKeysRef.current] = true;
+      }
+    };
+    const handleKeyUp = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      if (key in freeCamKeysRef.current) {
+        freeCamKeysRef.current[key as keyof typeof freeCamKeysRef.current] = false;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [isSpectator, cameraMode]);
 
   // Buffer incoming game states for interpolation
   useEffect(() => {
@@ -69,10 +105,27 @@ export const GameCanvas: React.FC<GameCanvasProps> = ({
       const interpolatedState = stateBufferRef.current.getInterpolatedState(currentTime);
 
       if (interpolatedState) {
-        // Update camera to follow current player's car
-        if (interpolatedState.cars.length > 0) {
-          const playerCar = interpolatedState.cars.find(car => car.isCurrentPlayer) || interpolatedState.cars[0];
-          camera.follow(playerCar.position.x, playerCar.position.y, 0.1);
+        // Update camera position
+        if (isSpectator && cameraMode === 'free') {
+          // Free camera - pan with WASD
+          const speed = 5;
+          const keys = freeCamKeysRef.current;
+          if (keys.w) camera.y -= speed;
+          if (keys.s) camera.y += speed;
+          if (keys.a) camera.x -= speed;
+          if (keys.d) camera.x += speed;
+        } else if (interpolatedState.cars.length > 0) {
+          // Follow mode - determine which car to follow
+          let targetCar;
+          if (isSpectator && spectatorTarget) {
+            // Follow specific spectator target
+            targetCar = interpolatedState.cars.find(car => car.playerId === spectatorTarget);
+          }
+          if (!targetCar) {
+            // Default: follow current player, or first car (race leader) for spectators
+            targetCar = interpolatedState.cars.find(car => car.isCurrentPlayer) || interpolatedState.cars[0];
+          }
+          camera.follow(targetCar.position.x, targetCar.position.y, 0.1);
         }
 
         // Apply camera transform
@@ -113,7 +166,7 @@ export const GameCanvas: React.FC<GameCanvasProps> = ({
       cancelAnimationFrame(animationFrameId);
       stateBufferRef.current.clear(); // Clear buffer on unmount
     };
-  }, [gameState, width, height]);
+  }, [gameState, width, height, isSpectator, spectatorTarget, cameraMode]);
 
   return (
     <div className="relative">

--- a/frontend/src/game/types.ts
+++ b/frontend/src/game/types.ts
@@ -108,6 +108,7 @@ export interface GameState {
   cars: CarState[];
   tick: number;
   raceInfo: RaceInfo;
+  spectatorCount?: number;
 }
 
 /**

--- a/frontend/src/pages/LobbyBrowser.tsx
+++ b/frontend/src/pages/LobbyBrowser.tsx
@@ -30,9 +30,12 @@ const LobbyBrowser: React.FC = () => {
 
   const loadLobbies = async () => {
     try {
-      // Only show waiting lobbies (joinable)
-      const data = await fetchLobbies('waiting');
-      setLobbies(data);
+      // Show waiting (joinable) and racing (spectatable) lobbies
+      const [waiting, racing] = await Promise.all([
+        fetchLobbies('waiting'),
+        fetchLobbies('racing'),
+      ]);
+      setLobbies([...waiting, ...racing]);
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load lobbies');
@@ -76,6 +79,16 @@ const LobbyBrowser: React.FC = () => {
 
   const handleJoinLobby = (lobbyId: string) => {
     navigate(`/lobby/${lobbyId}`);
+  };
+
+  const handleSpectateLobby = (lobby: LobbyListItem) => {
+    if (lobby.status === 'racing' && lobby.game_session_id) {
+      // Racing lobby - go directly to race as spectator
+      navigate(`/race?session_id=${lobby.game_session_id}&spectate=true`);
+    } else {
+      // Waiting lobby - go to waiting room as spectator
+      navigate(`/lobby/${lobby.lobby_id}?spectate=true`);
+    }
   };
 
   if (loading && lobbies.length === 0) {
@@ -135,19 +148,39 @@ const LobbyBrowser: React.FC = () => {
                   <p>
                     Players: {lobby.member_count} / {lobby.max_players}
                   </p>
-                  <p className="text-sm">Status: {lobby.status}</p>
+                  <p className="text-sm">
+                    Status:{' '}
+                    <span className={lobby.status === 'racing' ? 'text-green-400 font-semibold' : ''}>
+                      {lobby.status === 'racing' ? 'In Race' : lobby.status}
+                    </span>
+                  </p>
+                  {lobby.spectator_count > 0 && (
+                    <p className="text-sm text-gray-400">
+                      Spectators: {lobby.spectator_count}
+                    </p>
+                  )}
                 </div>
-                <button
-                  onClick={() => handleJoinLobby(lobby.lobby_id)}
-                  disabled={lobby.member_count >= lobby.max_players}
-                  className={`w-full py-2 rounded font-semibold ${
-                    lobby.member_count >= lobby.max_players
-                      ? 'bg-gray-600 cursor-not-allowed'
-                      : 'bg-green-600 hover:bg-green-500'
-                  }`}
-                >
-                  {lobby.member_count >= lobby.max_players ? 'Full' : 'Join Lobby'}
-                </button>
+                <div className="flex gap-2">
+                  {lobby.status === 'waiting' && (
+                    <button
+                      onClick={() => handleJoinLobby(lobby.lobby_id)}
+                      disabled={lobby.member_count >= lobby.max_players}
+                      className={`flex-1 py-2 rounded font-semibold ${
+                        lobby.member_count >= lobby.max_players
+                          ? 'bg-gray-600 cursor-not-allowed'
+                          : 'bg-green-600 hover:bg-green-500'
+                      }`}
+                    >
+                      {lobby.member_count >= lobby.max_players ? 'Full' : 'Join'}
+                    </button>
+                  )}
+                  <button
+                    onClick={() => handleSpectateLobby(lobby)}
+                    className={`${lobby.status === 'racing' ? 'flex-1' : ''} py-2 px-4 rounded font-semibold bg-purple-600 hover:bg-purple-500`}
+                  >
+                    Spectate
+                  </button>
+                </div>
               </div>
             ))}
           </div>

--- a/frontend/src/pages/LobbyWaitingRoom.tsx
+++ b/frontend/src/pages/LobbyWaitingRoom.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useEffect, useRef } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import type { Lobby, LobbyMember } from '../services';
 import { useUsername } from '../hooks/useUsername';
 import { getWsBaseUrl } from '../config';
@@ -18,6 +18,8 @@ interface LobbyState extends Lobby {}
 const LobbyWaitingRoom: React.FC = () => {
   const { lobbyId } = useParams<{ lobbyId: string }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const isSpectator = searchParams.get('spectate') === 'true';
   const { username, loading: usernameLoading } = useUsername();
 
   const [lobbyState, setLobbyState] = useState<LobbyState | null>(null);
@@ -39,6 +41,9 @@ const LobbyWaitingRoom: React.FC = () => {
     let wsUrl = `${WS_BASE_URL}/game/ws?lobby_id=${lobbyId}`;
     if (username) {
       wsUrl += `&player_id=${encodeURIComponent(username)}`;
+    }
+    if (isSpectator) {
+      wsUrl += '&spectate=true';
     }
 
     const ws = new WebSocket(wsUrl);
@@ -67,12 +72,19 @@ const LobbyWaitingRoom: React.FC = () => {
           setIsHost(message.data.player_id === message.data.lobby.host_player_id);
           break;
 
+        case 'spectator_joined':
+          // Successfully joined as spectator
+          setPlayerId(message.data.player_id);
+          setLobbyState(message.data.lobby);
+          setIsHost(false);
+          break;
+
         case 'lobby_state':
           // Full lobby state update
           const state: LobbyState = message.data;
           setLobbyState(state);
-          // Update isHost if needed
-          if (playerId) {
+          // Update isHost if needed (spectators are never host)
+          if (playerId && !isSpectator) {
             setIsHost(playerId === state.host_player_id);
           }
           break;
@@ -85,13 +97,14 @@ const LobbyWaitingRoom: React.FC = () => {
           // Member left - we'll get a lobby_state update
           break;
 
-        case 'race_starting':
+        case 'race_starting': {
           // Race is starting - navigate to race page with session and player ID
           const gameSessionId = message.data.game_session_id;
-          // Use username directly (it's what we used to join the lobby)
           const playerIdParam = username ? `&player_id=${encodeURIComponent(username)}` : '';
-          navigate(`/race?session_id=${gameSessionId}${playerIdParam}`);
+          const spectateParam = isSpectator ? '&spectate=true' : '';
+          navigate(`/race?session_id=${gameSessionId}${playerIdParam}${spectateParam}`);
           break;
+        }
 
         case 'error':
           setError(message.data.message);
@@ -123,7 +136,7 @@ const LobbyWaitingRoom: React.FC = () => {
         ws.close();
       }
     };
-  }, [lobbyId, navigate, username, usernameLoading]);
+  }, [lobbyId, navigate, username, usernameLoading, isSpectator]);
 
   const handleStartRace = () => {
     if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
@@ -165,12 +178,19 @@ const LobbyWaitingRoom: React.FC = () => {
         {/* Header */}
         <div className="mb-8">
           <div className="flex justify-between items-center mb-4">
-            <h1 className="text-4xl font-bold">{lobbyState.name}</h1>
+            <div className="flex items-center gap-3">
+              <h1 className="text-4xl font-bold">{lobbyState.name}</h1>
+              {isSpectator && (
+                <span className="px-3 py-1 bg-purple-700 text-purple-200 text-sm rounded font-semibold">
+                  SPECTATING
+                </span>
+              )}
+            </div>
             <button
               onClick={handleLeaveLobby}
               className="px-4 py-2 bg-red-700 hover:bg-red-600 rounded"
             >
-              Leave Lobby
+              {isSpectator ? 'Stop Spectating' : 'Leave Lobby'}
             </button>
           </div>
 
@@ -195,6 +215,14 @@ const LobbyWaitingRoom: React.FC = () => {
             <span>
               Players: {lobbyState.members.length} / {lobbyState.settings.max_players}
             </span>
+            {(lobbyState.spectator_count > 0) && (
+              <>
+                <span>•</span>
+                <span className="text-purple-400">
+                  Spectators: {lobbyState.spectator_count}
+                </span>
+              </>
+            )}
             <span>•</span>
             <span>Difficulty: {lobbyState.settings.track_difficulty}</span>
             {isHost && (
@@ -252,8 +280,14 @@ const LobbyWaitingRoom: React.FC = () => {
           </div>
         </div>
 
-        {/* Host Controls */}
-        {isHost ? (
+        {/* Host Controls / Waiting Messages */}
+        {isSpectator ? (
+          <div className="text-center py-12">
+            <p className="text-xl text-purple-400">
+              Spectating - waiting for race to start...
+            </p>
+          </div>
+        ) : isHost ? (
           <div className="mb-8">
             <h2 className="text-2xl font-bold mb-4">Host Controls</h2>
             <div className="bg-gray-800 border border-gray-700 rounded-lg p-6">

--- a/frontend/src/pages/MultiplayerRace.test.tsx
+++ b/frontend/src/pages/MultiplayerRace.test.tsx
@@ -408,3 +408,152 @@ describe('MultiplayerRace - Bot Submission', () => {
     });
   });
 });
+
+describe('MultiplayerRace - Spectator Mode', () => {
+  let mockWsInstance: any;
+  let mockCallbacks: any;
+  let originalSearch: string;
+
+  const setUrlSpectate = (value: boolean) => {
+    const search = value ? '?spectate=true' : '';
+    window.history.replaceState({}, '', `${window.location.pathname}${search}`);
+  };
+
+  const simulateConnect = () => {
+    vi.mocked(GameWebSocketClient).mockImplementation(function(this: any, callbacks: any) {
+      mockCallbacks = callbacks;
+      mockWsInstance = this;
+      this.callbacks = callbacks;
+      this.connect = vi.fn((sessionId, _difficulty, _seed, _playerId, _spectate) => {
+        setTimeout(() => {
+          callbacks.onConnected?.(sessionId || 'test-session-id', 'test-player-id', {
+            segments: [],
+            checkpoints: [],
+            start_position: [0, 0],
+            start_heading: 0,
+            obstacles: [],
+            containment: null,
+          } as any);
+        }, 0);
+      });
+      this.disconnect = vi.fn();
+      this.sendInput = vi.fn();
+      this.startRace = vi.fn();
+      this.sendBot = vi.fn();
+      this.isConnected = vi.fn(() => true);
+      return this;
+    } as any);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalSearch = window.location.search;
+    vi.mocked(botApi.getUserBots).mockResolvedValue([]);
+    simulateConnect();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.history.replaceState({}, '', `${window.location.pathname}${originalSearch}`);
+  });
+
+  it('renders SPECTATING badge when ?spectate=true is in the URL', async () => {
+    setUrlSpectate(true);
+    render(<MultiplayerRace />);
+
+    await waitFor(() => {
+      expect(screen.getByText('SPECTATING')).toBeInTheDocument();
+    });
+  });
+
+  it('does not render keyboard controls section when spectating', async () => {
+    setUrlSpectate(true);
+    render(<MultiplayerRace />);
+
+    await waitFor(() => {
+      expect(screen.getByText('SPECTATING')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/Keyboard Controls/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Start Race/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Share Session/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /New Track/i })).not.toBeInTheDocument();
+  });
+
+  it('renders camera controls (Follow/Free) when spectating with a game state', async () => {
+    setUrlSpectate(true);
+    render(<MultiplayerRace />);
+
+    await waitFor(() => {
+      expect(mockCallbacks).toBeDefined();
+    });
+
+    // Simulate a game state with one player car so playerList is non-empty
+    mockCallbacks.onGameState?.({
+      tick: 1,
+      race_info: {
+        status: 'waiting',
+        start_time: null,
+        countdown_remaining: 0,
+        finish_time: null,
+        first_finisher_time: null,
+        grace_period_remaining: 0,
+      },
+      players: {
+        'player-a': {
+          car: {
+            position: { x: 0, y: 0 },
+            velocity: { x: 0, y: 0 },
+            heading: 0,
+            angular_velocity: 0,
+            is_drifting: false,
+            drift_angle: 0,
+            nitro_charges: 3,
+            nitro_active: false,
+            nitro_remaining_ticks: 0,
+          },
+          current_checkpoint: 0,
+          split_times: [],
+          is_finished: false,
+          finish_time: null,
+          is_off_track: false,
+          position: null,
+          points: 0,
+          dnf: false,
+          is_bot: false,
+          bot_name: null,
+          bot_error: null,
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Follow Car/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Free Camera/i })).toBeInTheDocument();
+    });
+  });
+
+  it('connects to the WebSocket with spectate=true', async () => {
+    setUrlSpectate(true);
+    render(<MultiplayerRace />);
+
+    await waitFor(() => {
+      expect(mockWsInstance.connect).toHaveBeenCalled();
+    });
+
+    // 5th positional arg is `spectate`
+    const args = mockWsInstance.connect.mock.calls[0];
+    expect(args[4]).toBe(true);
+  });
+
+  it('does not render SPECTATING badge in normal (non-spectator) mode', async () => {
+    setUrlSpectate(false);
+    render(<MultiplayerRace />);
+
+    await waitFor(() => {
+      expect(mockCallbacks).toBeDefined();
+    });
+
+    expect(screen.queryByText('SPECTATING')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/MultiplayerRace.tsx
+++ b/frontend/src/pages/MultiplayerRace.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { GameCanvas, useKeyboardInput } from '../game';
-import type { GameState, Track, PlayerResult } from '../game/types';
+import type { GameState, Track, PlayerResult, InputState } from '../game/types';
 import { RaceHUD } from '../components/RaceHUD';
 import { CountdownOverlay } from '../components/CountdownOverlay';
 import { RaceResultsScreen } from '../components/RaceResultsScreen';
@@ -42,6 +42,15 @@ export default function MultiplayerRace() {
     const urlParams = new URLSearchParams(window.location.search);
     return urlParams.get('player_id') || undefined;
   }, []);
+
+  const isSpectator = useMemo(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    return urlParams.get('spectate') === 'true';
+  }, []);
+
+  // Spectator camera state
+  const [cameraMode, setCameraMode] = useState<'follow' | 'free'>('follow');
+  const [followTarget, setFollowTarget] = useState<string | null>(null);
 
   const inputState = useKeyboardInput();
   const wsRef = useRef<GameWebSocketClient | null>(null);
@@ -95,14 +104,17 @@ export default function MultiplayerRace() {
         const currentPlayerId = playerIdRef.current;
 
         // Convert server state to frontend GameState format
-        if (!currentTrack || !currentPlayerId) {
-          console.warn('Missing track or playerId, skipping game state update');
+        if (!currentTrack) {
+          console.warn('Missing track, skipping game state update');
           return;
         }
 
-        const playerData = state.players[currentPlayerId];
-        if (!playerData) {
-          console.warn('No player data found for player:', currentPlayerId);
+        // For spectators, use the first player's data as reference for race info
+        const playerIds = Object.keys(state.players);
+        const playerData = currentPlayerId ? state.players[currentPlayerId] : null;
+        const referencePlayer = playerData || (playerIds.length > 0 ? state.players[playerIds[0]] : null);
+
+        if (!referencePlayer) {
           return;
         }
 
@@ -126,17 +138,18 @@ export default function MultiplayerRace() {
             botName: pData.bot_name,
           })),
           tick: state.tick,
+          spectatorCount: (state as any).spectator_count || 0,
           raceInfo: {
-            currentCheckpoint: playerData.current_checkpoint,
+            currentCheckpoint: referencePlayer.current_checkpoint,
             totalCheckpoints: currentTrack.checkpoints.length,
-            isFinished: playerData.is_finished,
-            finishTime: playerData.finish_time,
+            isFinished: referencePlayer.is_finished,
+            finishTime: referencePlayer.finish_time,
             startTime: state.race_info.start_time,
             countdownRemaining: state.race_info.countdown_remaining,
             raceStatus: state.race_info.status,
             firstFinisherTime: state.race_info.first_finisher_time,
             gracePeriodRemaining: state.race_info.grace_period_remaining,
-            currentPosition: playerData.position,
+            currentPosition: referencePlayer.position,
             totalPlayers: Object.keys(state.players).length,
           }
         };
@@ -189,7 +202,7 @@ export default function MultiplayerRace() {
     });
 
     wsRef.current = ws;
-    ws.connect(sessionIdFromUrl, 'medium', seed, playerIdFromUrl);  // Connect with session and player ID from URL
+    ws.connect(sessionIdFromUrl, 'medium', seed, playerIdFromUrl, isSpectator);  // Connect with session and player ID from URL
 
     // Cleanup on unmount
     return () => {
@@ -303,93 +316,188 @@ export default function MultiplayerRace() {
     );
   }
 
+  // Get list of player IDs for spectator follow target selection
+  const playerList = gameState ? gameState.cars
+    .filter(car => car.playerId)
+    .map(car => ({
+      id: car.playerId!,
+      name: car.botName || car.playerId!.substring(0, 12),
+      isBot: car.isBot,
+    })) : [];
+
   return (
     <div className="p-8">
-      <h2 className="text-3xl font-bold mb-4">Multiplayer Rally Stage (Server-Authoritative)</h2>
+      <div className="flex items-center gap-3 mb-4">
+        <h2 className="text-3xl font-bold">Multiplayer Rally Stage</h2>
+        {isSpectator && (
+          <span className="px-3 py-1 bg-purple-700 text-purple-200 text-sm rounded font-semibold">
+            SPECTATING
+          </span>
+        )}
+      </div>
       <div className="mb-4 flex gap-4 items-center flex-wrap">
         <div className="text-gray-300">
           <span className="font-semibold">Session:</span> {sessionId?.substring(0, 8)}...
-          {sessionIdFromUrl && (
-            <span className="ml-2 px-2 py-1 text-xs bg-blue-600 rounded">Joined</span>
-          )}
         </div>
-        <div className="text-gray-300">
-          <span className="font-semibold">Player ID:</span> {playerId?.substring(0, 8)}...
-        </div>
-        <div className="text-gray-300">
-          <span className="font-semibold">Players:</span> {gameState?.raceInfo.totalPlayers || 1}
-        </div>
-        <div className="text-gray-300">
-          <span className="font-semibold">Track Seed:</span> {seed}
-          <button
-            onClick={() => navigator.clipboard.writeText(seed.toString())}
-            className="ml-2 px-2 py-1 text-xs bg-gray-700 rounded hover:bg-gray-600"
-            title="Copy seed to clipboard"
-          >
-            📋 Copy
-          </button>
-        </div>
-        <button
-          onClick={handleShareSession}
-          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-          title="Copy shareable session link to clipboard"
-        >
-          👥 Share Session
-        </button>
-        {!raceStarted && (
-          <button
-            onClick={handleStartRace}
-            className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
-          >
-            Start Race
-          </button>
+        {!isSpectator && (
+          <div className="text-gray-300">
+            <span className="font-semibold">Player ID:</span> {playerId?.substring(0, 8)}...
+          </div>
         )}
-        {userBots.length > 0 && (
-          <div className="flex gap-2 items-center">
-            <select
-              value={selectedBotId || ''}
-              onChange={(e) => setSelectedBotId(Number(e.target.value))}
-              className="px-3 py-2 bg-gray-700 text-white rounded border border-gray-600"
-            >
-              {userBots.map((bot) => (
-                <option key={bot.id} value={bot.id}>{bot.name}</option>
-              ))}
-            </select>
+        <div className="text-gray-300">
+          <span className="font-semibold">Players:</span> {gameState?.raceInfo.totalPlayers || 0}
+        </div>
+        {(gameState?.spectatorCount ?? 0) > 0 && (
+          <div className="text-purple-400">
+            <span className="font-semibold">Spectators:</span> {gameState?.spectatorCount}
+          </div>
+        )}
+        {!isSpectator && (
+          <>
+            <div className="text-gray-300">
+              <span className="font-semibold">Track Seed:</span> {seed}
+              <button
+                onClick={() => navigator.clipboard.writeText(seed.toString())}
+                className="ml-2 px-2 py-1 text-xs bg-gray-700 rounded hover:bg-gray-600"
+                title="Copy seed to clipboard"
+              >
+                Copy
+              </button>
+            </div>
             <button
-              onClick={handleSubmitBot}
-              disabled={!selectedBotId || gameState?.raceInfo.raceStatus === 'countdown' || gameState?.raceInfo.raceStatus === 'finished'}
-              className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700 disabled:bg-gray-600 disabled:cursor-not-allowed"
+              onClick={handleShareSession}
+              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+              title="Copy shareable session link to clipboard"
             >
-              Submit Bot
+              Share Session
             </button>
-          </div>
+            {!raceStarted && (
+              <button
+                onClick={handleStartRace}
+                className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+              >
+                Start Race
+              </button>
+            )}
+            {userBots.length > 0 && (
+              <div className="flex gap-2 items-center">
+                <select
+                  value={selectedBotId || ''}
+                  onChange={(e) => setSelectedBotId(Number(e.target.value))}
+                  className="px-3 py-2 bg-gray-700 text-white rounded border border-gray-600"
+                >
+                  {userBots.map((bot) => (
+                    <option key={bot.id} value={bot.id}>{bot.name}</option>
+                  ))}
+                </select>
+                <button
+                  onClick={handleSubmitBot}
+                  disabled={!selectedBotId || gameState?.raceInfo.raceStatus === 'countdown' || gameState?.raceInfo.raceStatus === 'finished'}
+                  className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700 disabled:bg-gray-600 disabled:cursor-not-allowed"
+                >
+                  Submit Bot
+                </button>
+              </div>
+            )}
+            {botSubmissionStatus && (
+              <div className={`px-4 py-2 rounded ${
+                botSubmissionStatus.startsWith('✓')
+                  ? 'bg-green-600/20 text-green-400 border border-green-600'
+                  : botSubmissionStatus.startsWith('✗')
+                  ? 'bg-red-600/20 text-red-400 border border-red-600'
+                  : 'bg-blue-600/20 text-blue-400 border border-blue-600'
+              }`}>
+                {botSubmissionStatus}
+              </div>
+            )}
+            <button
+              onClick={() => window.location.reload()}
+              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+              title="Generate new random track"
+            >
+              New Track
+            </button>
+          </>
         )}
-        {botSubmissionStatus && (
-          <div className={`px-4 py-2 rounded ${
-            botSubmissionStatus.startsWith('✓')
-              ? 'bg-green-600/20 text-green-400 border border-green-600'
-              : botSubmissionStatus.startsWith('✗')
-              ? 'bg-red-600/20 text-red-400 border border-red-600'
-              : 'bg-blue-600/20 text-blue-400 border border-blue-600'
-          }`}>
-            {botSubmissionStatus}
-          </div>
-        )}
-        <button
-          onClick={() => window.location.reload()}
-          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-          title="Generate new random track"
-        >
-          🔄 New Track
-        </button>
       </div>
 
-      <p className="text-gray-300 mb-4">
-        Physics running on server at 60Hz. Click "👥 Share Session" to race with friends in real-time! Multiple humans, bots, or both can race together.
-      </p>
+      {/* Spectator Camera Controls */}
+      {isSpectator && gameState && playerList.length > 0 && (
+        <div className="mb-4 flex gap-4 items-center flex-wrap bg-gray-800 p-3 rounded-lg">
+          <span className="font-semibold text-gray-300">Camera:</span>
+          <button
+            onClick={() => setCameraMode('follow')}
+            className={`px-3 py-1 rounded ${cameraMode === 'follow' ? 'bg-purple-600' : 'bg-gray-700 hover:bg-gray-600'}`}
+          >
+            Follow Car
+          </button>
+          <button
+            onClick={() => setCameraMode('free')}
+            className={`px-3 py-1 rounded ${cameraMode === 'free' ? 'bg-purple-600' : 'bg-gray-700 hover:bg-gray-600'}`}
+          >
+            Free Camera
+          </button>
+          {cameraMode === 'follow' && (
+            <>
+              <span className="text-gray-400">|</span>
+              <span className="text-gray-300 text-sm">Following:</span>
+              <select
+                value={followTarget || ''}
+                onChange={(e) => setFollowTarget(e.target.value || null)}
+                className="px-3 py-1 bg-gray-700 text-white rounded border border-gray-600 text-sm"
+              >
+                <option value="">Race Leader</option>
+                {playerList.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}{p.isBot ? ' (Bot)' : ''}
+                  </option>
+                ))}
+              </select>
+              <button
+                onClick={() => {
+                  const idx = playerList.findIndex(p => p.id === followTarget);
+                  const prevIdx = idx <= 0 ? playerList.length - 1 : idx - 1;
+                  setFollowTarget(playerList[prevIdx].id);
+                }}
+                className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded text-sm"
+                title="Previous car"
+              >
+                Prev
+              </button>
+              <button
+                onClick={() => {
+                  const idx = playerList.findIndex(p => p.id === followTarget);
+                  const nextIdx = idx >= playerList.length - 1 ? 0 : idx + 1;
+                  setFollowTarget(playerList[nextIdx].id);
+                }}
+                className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded text-sm"
+                title="Next car"
+              >
+                Next
+              </button>
+            </>
+          )}
+          {cameraMode === 'free' && (
+            <span className="text-gray-400 text-sm">Use WASD to pan camera</span>
+          )}
+        </div>
+      )}
+
+      {!isSpectator && (
+        <p className="text-gray-300 mb-4">
+          Physics running on server at 60Hz. Click "Share Session" to race with friends in real-time!
+        </p>
+      )}
 
       <div className="mt-8 bg-gray-800 p-4 rounded-lg relative">
-        <GameCanvas gameState={gameState} width={800} height={600} />
+        <GameCanvas
+          gameState={gameState}
+          width={800}
+          height={600}
+          isSpectator={isSpectator}
+          spectatorTarget={followTarget}
+          cameraMode={cameraMode}
+        />
         {gameState && <RaceHUD raceInfo={gameState.raceInfo} car={gameState.cars[0]} />}
         {gameState && (
           <CountdownOverlay
@@ -408,64 +516,51 @@ export default function MultiplayerRace() {
         )}
       </div>
 
-      {/* Keyboard Input Display */}
-      <div className="mt-4 bg-gray-800 p-4 rounded-lg">
-        <h3 className="text-lg font-semibold mb-3">Keyboard Controls (Sent to Server)</h3>
-        <p className="text-sm text-gray-400 mb-3">
-          {gameState?.raceInfo.raceStatus === 'countdown' || gameState?.raceInfo.raceStatus === 'waiting' ? (
-            <span className="text-yellow-400 font-semibold">🔒 Controls locked during countdown</span>
-          ) : (
-            <span>Inputs sent only when changed (optimized network traffic)</span>
-          )}
-        </p>
-        <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
-          <div className={`p-3 rounded text-center transition-colors ${
-            inputState.accelerate ? 'bg-green-600' : 'bg-gray-700'
-          }`}>
-            <div className="font-semibold">Accelerate</div>
-            <div className="text-sm text-gray-300">W / ↑</div>
-          </div>
-          <div className={`p-3 rounded text-center transition-colors ${
-            inputState.brake ? 'bg-red-600' : 'bg-gray-700'
-          }`}>
-            <div className="font-semibold">Brake</div>
-            <div className="text-sm text-gray-300">S / ↓</div>
-          </div>
-          <div className={`p-3 rounded text-center transition-colors ${
-            inputState.turnLeft ? 'bg-blue-600' : 'bg-gray-700'
-          }`}>
-            <div className="font-semibold">Turn Left</div>
-            <div className="text-sm text-gray-300">A / ←</div>
-          </div>
-          <div className={`p-3 rounded text-center transition-colors ${
-            inputState.turnRight ? 'bg-blue-600' : 'bg-gray-700'
-          }`}>
-            <div className="font-semibold">Turn Right</div>
-            <div className="text-sm text-gray-300">D / →</div>
-          </div>
-          <div className={`p-3 rounded text-center transition-colors ${
-            inputState.nitro ? 'bg-purple-600' : 'bg-gray-700'
-          }`}>
-            <div className="font-semibold">Nitro</div>
-            <div className="text-sm text-gray-300">Space</div>
+      {/* Keyboard Input Display (hidden for spectators) */}
+      {!isSpectator && (
+        <div className="mt-4 bg-gray-800 p-4 rounded-lg">
+          <h3 className="text-lg font-semibold mb-3">Keyboard Controls (Sent to Server)</h3>
+          <p className="text-sm text-gray-400 mb-3">
+            {gameState?.raceInfo.raceStatus === 'countdown' || gameState?.raceInfo.raceStatus === 'waiting' ? (
+              <span className="text-yellow-400 font-semibold">Controls locked during countdown</span>
+            ) : (
+              <span>Inputs sent only when changed (optimized network traffic)</span>
+            )}
+          </p>
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+            <div className={`p-3 rounded text-center transition-colors ${
+              inputState.accelerate ? 'bg-green-600' : 'bg-gray-700'
+            }`}>
+              <div className="font-semibold">Accelerate</div>
+              <div className="text-sm text-gray-300">W / Up</div>
+            </div>
+            <div className={`p-3 rounded text-center transition-colors ${
+              inputState.brake ? 'bg-red-600' : 'bg-gray-700'
+            }`}>
+              <div className="font-semibold">Brake</div>
+              <div className="text-sm text-gray-300">S / Down</div>
+            </div>
+            <div className={`p-3 rounded text-center transition-colors ${
+              inputState.turnLeft ? 'bg-blue-600' : 'bg-gray-700'
+            }`}>
+              <div className="font-semibold">Turn Left</div>
+              <div className="text-sm text-gray-300">A / Left</div>
+            </div>
+            <div className={`p-3 rounded text-center transition-colors ${
+              inputState.turnRight ? 'bg-blue-600' : 'bg-gray-700'
+            }`}>
+              <div className="font-semibold">Turn Right</div>
+              <div className="text-sm text-gray-300">D / Right</div>
+            </div>
+            <div className={`p-3 rounded text-center transition-colors ${
+              inputState.nitro ? 'bg-purple-600' : 'bg-gray-700'
+            }`}>
+              <div className="font-semibold">Nitro</div>
+              <div className="text-sm text-gray-300">Space</div>
+            </div>
           </div>
         </div>
-      </div>
-
-      <div className="mt-4 text-sm text-gray-400">
-        <p>Server-Authoritative Features:</p>
-        <ul className="list-disc list-inside ml-4 mt-2">
-          <li>Server runs physics at fixed 60Hz tick rate</li>
-          <li>Client sends inputs only when changed (optimized network traffic)</li>
-          <li>Server broadcasts state updates at 60 FPS</li>
-          <li>Obstacle collision handled server-side</li>
-          <li>Checkpoint progress tracked server-side</li>
-          <li><strong>Real-time multiplayer!</strong> Click "👥 Share Session" to race with friends</li>
-          <li>Human vs human, bot vs bot, or mixed races supported</li>
-          <li>Random track generation - each reload creates a new track!</li>
-          <li>Reproducible tracks - use <code>?seed=123</code> in URL to load a specific track</li>
-        </ul>
-      </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/services/gameWebSocket.ts
+++ b/frontend/src/services/gameWebSocket.ts
@@ -87,6 +87,7 @@ export class GameWebSocketClient {
   private callbacks: GameWebSocketCallbacks;
   private reconnectTimeout: number | null = null;
   private shouldReconnect: boolean = true;
+  private _isSpectator: boolean = false;
 
   public sessionId: string | null = null;
   public playerId: string | null = null;
@@ -95,10 +96,17 @@ export class GameWebSocketClient {
     this.callbacks = callbacks;
   }
 
+  /** Whether this client is connected as a spectator. */
+  get isSpectator(): boolean {
+    return this._isSpectator;
+  }
+
   /**
    * Connect to the game server.
    */
-  connect(sessionId?: string, difficulty: string = 'medium', seed?: number, playerId?: string): void {
+  connect(sessionId?: string, difficulty: string = 'medium', seed?: number, playerId?: string, spectate?: boolean): void {
+    this._isSpectator = spectate || false;
+
     // Build WebSocket URL with query parameters
     const url = new URL(`${WS_BASE_URL}/game/ws`);
     if (sessionId) {
@@ -110,6 +118,9 @@ export class GameWebSocketClient {
     }
     if (playerId) {
       url.searchParams.append('player_id', playerId);
+    }
+    if (spectate) {
+      url.searchParams.append('spectate', 'true');
     }
 
     this.ws = new WebSocket(url.toString());
@@ -166,10 +177,10 @@ export class GameWebSocketClient {
   }
 
   /**
-   * Send player input to the server.
+   * Send player input to the server. No-op for spectators.
    */
   sendInput(input: InputState): void {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN || this._isSpectator) {
       return;
     }
 

--- a/frontend/src/services/lobbyApi.ts
+++ b/frontend/src/services/lobbyApi.ts
@@ -32,6 +32,8 @@ export interface LobbyListItem {
   max_players: number;
   status: string;
   created_at: number;
+  spectator_count: number;
+  game_session_id: string | null;
 }
 
 export interface Lobby {
@@ -44,6 +46,7 @@ export interface Lobby {
   status: string;
   created_at: number;
   game_session_id: string | null;
+  spectator_count: number;
 }
 
 export interface CreateLobbyRequest {


### PR DESCRIPTION
## Summary

Implements spectator mode for race lobbies (closes #127). Users can now watch any waiting or racing lobby without participating.

## What's in

**Backend**
- `Lobby` / `LobbyManager` track spectators in a separate dict so they don't affect member count, `is_full`, `can_start_race`, or host transfer.
- WebSocket endpoint accepts `?spectate=true`, routes through new `handle_spectate_lobby` / `handle_leave_spectate` handlers, silently ignores spectator inputs, and broadcasts `lobby_state` + `game_state` to spectator connections.
- REST lobby responses include `spectator_count` and `game_session_id` so the browser can offer Spectate buttons on racing lobbies.

**Frontend**
- `LobbyBrowser` now lists both waiting and racing lobbies, with a Spectate button on each; routes spectators to the waiting room (waiting status) or directly into the race view (racing status).
- `LobbyWaitingRoom` shows a SPECTATING badge, hides host controls for spectators, forwards the spectate flag to the race page on race start.
- `MultiplayerRace` shows a SPECTATING badge, hides input / bot / share / start UI, and adds a camera-control panel (Follow / Free Camera, per-car follow target with Prev/Next).
- `GameCanvas` gains `isSpectator`, `spectatorTarget`, `cameraMode` props; supports WASD pan in free mode; follow-target lookup falls back to the race leader.

## Tests

- **Backend:** 21 unit tests on lobby spectator data structures + 7 new WebSocket integration tests (join waiting lobby, error on missing lobby, multiple spectators, input ignored, disconnect cleanup, explicit leave_lobby).
- **Frontend:** 5 new component tests covering badge presence, hidden input UI, camera-control rendering, the spectate flag passed to `connect`, and the non-spectator default.
- Full suite: backend 295/295 ✓, frontend 17/17 ✓.

## Test plan

- [x] `cd backend && ./venv/bin/python -m pytest tests/ -v` — all pass
- [x] `cd frontend && npm test -- --run` — all pass
- [x] Manual smoke test: two browser windows; one hosts a race, one spectates from the lobby browser. Verified SPECTATING badge, hidden controls, spectator count visibility to host, camera toggle, car switcher, WASD pan, and clean disconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)