### PR TITLE
feat: add MLX runtime + LLM strategist scaffold (#152)

### DIFF
--- a/backend/app/agents/__init__.py
+++ b/backend/app/agents/__init__.py
@@ -1,0 +1,17 @@
+"""LLM-driven agent infrastructure (issue #151 / #152).
+
+This package implements the trusted-code side of the two-tier LLM agent:
+a high-rate deterministic controller will consume the latest `Intent`
+produced by `LLMStrategist`, which itself runs at ~1Hz on top of a
+pluggable `generate_fn` (MLX in production, mocks in tests).
+
+Public API:
+    - Intent: the structured driving intent schema
+    - LLMStrategist: async runner that turns observations into Intents
+    - MLXRuntime / get_mlx_generate_fn: optional MLX-backed generation
+"""
+
+from app.agents.intent import Intent
+from app.agents.llm_strategist import LLMStrategist
+
+__all__ = ["Intent", "LLMStrategist"]

--- a/backend/app/agents/intent.py
+++ b/backend/app/agents/intent.py
@@ -1,0 +1,18 @@
+"""Structured driving intent emitted by the LLM strategist (issue #152)."""
+
+from pydantic import BaseModel, Field
+
+
+class Intent(BaseModel):
+    """High-level driving intent produced by the strategist at ~1Hz.
+
+    The deterministic controller consumes the latest Intent every tick
+    (20Hz) and translates it into concrete steer/throttle/brake inputs.
+
+    Bounds are intentionally generous: the controller is responsible for
+    clamping to physically achievable values for the current car/surface.
+    """
+
+    target_speed_kmh: float = Field(ge=0, le=400)
+    racing_line_offset_m: float = Field(ge=-20, le=20)
+    aggression: float = Field(ge=0, le=1)

--- a/backend/app/agents/llm_strategist.py
+++ b/backend/app/agents/llm_strategist.py
@@ -1,0 +1,160 @@
+"""Async LLM strategist (issue #152).
+
+Owns one async task per car. Pulls the latest observation, asks the
+injected generate_fn for an Intent (JSON), parses it, and exposes the
+latest valid Intent via a synchronous accessor for the 20Hz controller.
+
+Failures are non-fatal: timeouts, parse errors, validation errors, and
+any other exceptions are swallowed and the previous valid Intent is
+preserved. If no Intent has ever been produced, latest_intent() returns
+None and the controller must fall back to its own safe defaults.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Awaitable, Callable, Optional
+
+from pydantic import ValidationError
+
+from app.agents.intent import Intent
+
+logger = logging.getLogger(__name__)
+
+
+GenerateFn = Callable[[str], Awaitable[str]]
+
+
+_SYSTEM_PROMPT = (
+    "You are driving a rally car. Given the current observation, decide your "
+    "high-level driving intent for the next second.\n"
+    "Output ONLY a JSON object with exactly these fields:\n"
+    '  "target_speed_kmh": number, 0..300\n'
+    '  "racing_line_offset_m": number, -10..10  (negative = left of centre)\n'
+    '  "aggression": number, 0..1  (0 = cautious, 1 = aggressive)\n'
+    "Output nothing else. No prose, no markdown, no code fences."
+)
+
+
+def build_prompt(observation: str) -> str:
+    """Assemble the full prompt sent to the generation backend."""
+    return (
+        f"{_SYSTEM_PROMPT}\n\n"
+        f"Observation:\n{observation}\n\n"
+        f"Intent JSON:"
+    )
+
+
+class LLMStrategist:
+    """Run an LLM at ~1Hz to translate observations into Intents.
+
+    Args:
+        generate_fn: async callable taking a prompt and returning text.
+            In production this is backed by MLX (see mlx_runtime); in
+            tests it is a mock that lets us drive every code path
+            without loading a real model.
+        tick_interval_s: how often the background loop calls generate_fn.
+        timeout_s: per-call timeout. Timeouts are dropped, not raised.
+    """
+
+    def __init__(
+        self,
+        generate_fn: GenerateFn,
+        tick_interval_s: float = 1.0,
+        timeout_s: float = 2.0,
+    ) -> None:
+        self._generate_fn = generate_fn
+        self._tick_interval_s = tick_interval_s
+        self._timeout_s = timeout_s
+        self._latest_observation: Optional[str] = None
+        self._latest_intent: Optional[Intent] = None
+        self._task: Optional[asyncio.Task] = None
+
+    def set_observation(self, observation: str) -> None:
+        """Update the observation seen by the next tick."""
+        self._latest_observation = observation
+
+    def latest_intent(self) -> Optional[Intent]:
+        """Return the most recently parsed Intent, or None if none yet."""
+        return self._latest_intent
+
+    async def tick_once(self) -> Optional[Intent]:
+        """Run a single generate+parse cycle.
+
+        Exposed for deterministic testing. Returns the Intent produced
+        this tick (which is also stored in latest_intent), or None if
+        the call timed out, failed, or produced unparseable output.
+        Never raises.
+        """
+        observation = self._latest_observation
+        if observation is None:
+            return None
+
+        try:
+            raw = await asyncio.wait_for(
+                self._generate_fn(build_prompt(observation)),
+                timeout=self._timeout_s,
+            )
+        except asyncio.TimeoutError:
+            logger.debug("LLM strategist tick timed out after %.1fs", self._timeout_s)
+            return None
+        except Exception:
+            logger.exception("LLM strategist generate_fn raised")
+            return None
+
+        intent = _parse_intent(raw)
+        if intent is not None:
+            self._latest_intent = intent
+        return intent
+
+    async def start(self) -> None:
+        """Spawn the background tick loop. No-op if already running."""
+        if self._task is not None and not self._task.done():
+            return
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        """Cancel the background tick loop and wait for it to exit."""
+        if self._task is None:
+            return
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        self._task = None
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                await self.tick_once()
+                await asyncio.sleep(self._tick_interval_s)
+        except asyncio.CancelledError:
+            raise
+
+
+def _parse_intent(raw: str) -> Optional[Intent]:
+    """Extract an Intent from raw model output. Tolerates surrounding noise."""
+    if not raw:
+        return None
+
+    # Find the first {...} block. Models often emit a code fence or a stray
+    # leading token despite the system prompt. We do not attempt brace
+    # balancing for nested JSON because the Intent schema is flat.
+    start = raw.find("{")
+    end = raw.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    candidate = raw[start : end + 1]
+
+    try:
+        data = json.loads(candidate)
+    except json.JSONDecodeError:
+        return None
+
+    try:
+        return Intent.model_validate(data)
+    except ValidationError:
+        return None

--- a/backend/app/agents/mlx_runtime.py
+++ b/backend/app/agents/mlx_runtime.py
@@ -1,0 +1,79 @@
+"""MLX-backed generation for the LLM strategist (issue #152).
+
+MLX is an optional dependency. This module imports cleanly without it
+installed; the runtime check happens only when something tries to use
+the model. Install with `pip install -r backend/requirements-agents.txt`
+to enable LLM agents.
+
+Default model: Qwen/Qwen2.5-1.5B-Instruct (Q4-quantized variant on the
+mlx-community hub). Override with the MLX_MODEL_PATH env var.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_MODEL_PATH = os.environ.get(
+    "MLX_MODEL_PATH",
+    "mlx-community/Qwen2.5-1.5B-Instruct-4bit",
+)
+
+
+class MLXRuntime:
+    """Lazily-loaded singleton wrapping the mlx-lm model+tokenizer."""
+
+    _instance: Optional["MLXRuntime"] = None
+
+    def __init__(self, model_path: str = DEFAULT_MODEL_PATH, max_tokens: int = 64) -> None:
+        try:
+            from mlx_lm import load, generate
+        except ImportError as exc:
+            raise RuntimeError(
+                "MLX is not installed. Install backend/requirements-agents.txt "
+                "to enable LLM agents (Apple Silicon only)."
+            ) from exc
+
+        logger.info("Loading MLX model: %s", model_path)
+        self._model, self._tokenizer = load(model_path)
+        self._generate = generate
+        self._max_tokens = max_tokens
+        logger.info("MLX model loaded")
+
+    async def generate(self, prompt: str) -> str:
+        """Async wrapper around the synchronous mlx-lm generate call."""
+        return await asyncio.to_thread(
+            self._generate,
+            self._model,
+            self._tokenizer,
+            prompt=prompt,
+            max_tokens=self._max_tokens,
+            verbose=False,
+        )
+
+
+def get_runtime() -> MLXRuntime:
+    """Return the process-wide MLXRuntime singleton (loads on first call)."""
+    if MLXRuntime._instance is None:
+        MLXRuntime._instance = MLXRuntime()
+    return MLXRuntime._instance
+
+
+def get_mlx_generate_fn():
+    """Return an async generate_fn suitable for LLMStrategist."""
+    runtime = get_runtime()
+    return runtime.generate
+
+
+def is_available() -> bool:
+    """Check whether MLX can be imported, without loading a model."""
+    try:
+        import mlx_lm  # noqa: F401
+        return True
+    except ImportError:
+        return False

--- a/backend/requirements-agents.txt
+++ b/backend/requirements-agents.txt
@@ -1,0 +1,9 @@
+# Optional dependencies for the LLM agent (issue #151).
+# Required only if you want to run LLM-driven cars locally.
+# Apple Silicon only.
+#
+# Install with:
+#   pip install -r backend/requirements-agents.txt
+
+mlx>=0.18.0
+mlx-lm>=0.19.0

--- a/backend/tests/test_llm_strategist.py
+++ b/backend/tests/test_llm_strategist.py
@@ -1,0 +1,237 @@
+"""Unit tests for the LLM strategist (issue #152).
+
+Covers:
+- Intent schema validation
+- JSON parsing robustness (well-formed, malformed, missing fields,
+  out-of-range values, surrounding noise, code fences)
+- tick_once() preserves last-good Intent on parse/validation failure
+- Per-call timeout drops the tick without raising
+- Generate-fn exceptions are swallowed
+- Start/stop lifecycle of the background loop
+
+All tests use an injected fake generate_fn — no MLX required.
+A separate MLX-gated integration test lives in test_mlx_runtime.py.
+"""
+
+import asyncio
+from typing import List
+
+import pytest
+
+from app.agents.intent import Intent
+from app.agents.llm_strategist import LLMStrategist, _parse_intent, build_prompt
+
+
+def _make_fake_generate(responses: List[str]):
+    """Return an async generate_fn that yields the given responses in order."""
+    iterator = iter(responses)
+
+    async def fake_generate(_prompt: str) -> str:
+        try:
+            return next(iterator)
+        except StopIteration:
+            # Repeat the last response indefinitely
+            return responses[-1] if responses else ""
+
+    return fake_generate
+
+
+# ===== Intent schema =====
+
+
+class TestIntentSchema:
+    def test_accepts_valid_intent(self):
+        intent = Intent(target_speed_kmh=80, racing_line_offset_m=0.5, aggression=0.6)
+        assert intent.target_speed_kmh == 80
+        assert intent.racing_line_offset_m == 0.5
+        assert intent.aggression == 0.6
+
+    def test_rejects_negative_speed(self):
+        with pytest.raises(Exception):
+            Intent(target_speed_kmh=-10, racing_line_offset_m=0, aggression=0.5)
+
+    def test_rejects_excessive_aggression(self):
+        with pytest.raises(Exception):
+            Intent(target_speed_kmh=80, racing_line_offset_m=0, aggression=1.5)
+
+    def test_rejects_offset_out_of_bounds(self):
+        with pytest.raises(Exception):
+            Intent(target_speed_kmh=80, racing_line_offset_m=999, aggression=0.5)
+
+
+# ===== Pure parser =====
+
+
+class TestParseIntent:
+    def test_parses_clean_json(self):
+        raw = '{"target_speed_kmh": 90, "racing_line_offset_m": -1.0, "aggression": 0.4}'
+        intent = _parse_intent(raw)
+        assert intent is not None
+        assert intent.target_speed_kmh == 90
+
+    def test_parses_with_leading_and_trailing_noise(self):
+        raw = (
+            "Here is the intent:\n"
+            '```json\n{"target_speed_kmh": 75, "racing_line_offset_m": 0, "aggression": 0.5}\n```\n'
+            "Good luck!"
+        )
+        intent = _parse_intent(raw)
+        assert intent is not None
+        assert intent.target_speed_kmh == 75
+
+    def test_returns_none_on_empty_string(self):
+        assert _parse_intent("") is None
+
+    def test_returns_none_when_no_braces(self):
+        assert _parse_intent("hello world") is None
+
+    def test_returns_none_on_invalid_json(self):
+        # Unclosed quote
+        assert _parse_intent('{"target_speed_kmh": "abc, "aggression": 0.5}') is None
+
+    def test_returns_none_on_missing_field(self):
+        assert _parse_intent('{"target_speed_kmh": 80}') is None
+
+    def test_returns_none_on_out_of_range(self):
+        raw = '{"target_speed_kmh": 80, "racing_line_offset_m": 0, "aggression": 5}'
+        assert _parse_intent(raw) is None
+
+
+# ===== build_prompt =====
+
+
+class TestBuildPrompt:
+    def test_includes_observation(self):
+        prompt = build_prompt("speed=80 km/h, next checkpoint 100m ahead")
+        assert "speed=80 km/h" in prompt
+        assert "next checkpoint 100m ahead" in prompt
+
+    def test_instructs_json_only_output(self):
+        prompt = build_prompt("anything")
+        # Sanity-check the prompt steers the model toward JSON
+        assert "JSON" in prompt
+        assert "target_speed_kmh" in prompt
+
+
+# ===== LLMStrategist.tick_once =====
+
+
+class TestStrategistTickOnce:
+    @pytest.mark.asyncio
+    async def test_returns_none_with_no_observation(self):
+        strategist = LLMStrategist(_make_fake_generate(["{}"]))
+        result = await strategist.tick_once()
+        assert result is None
+        assert strategist.latest_intent() is None
+
+    @pytest.mark.asyncio
+    async def test_produces_intent_from_well_formed_output(self):
+        raw = '{"target_speed_kmh": 100, "racing_line_offset_m": 2.0, "aggression": 0.7}'
+        strategist = LLMStrategist(_make_fake_generate([raw]))
+        strategist.set_observation("dummy obs")
+
+        result = await strategist.tick_once()
+        assert result is not None
+        assert result.target_speed_kmh == 100
+        assert strategist.latest_intent() == result
+
+    @pytest.mark.asyncio
+    async def test_preserves_last_good_intent_on_parse_failure(self):
+        good = '{"target_speed_kmh": 60, "racing_line_offset_m": 0, "aggression": 0.3}'
+        bad = "not a json output"
+        strategist = LLMStrategist(_make_fake_generate([good, bad]))
+        strategist.set_observation("obs")
+
+        first = await strategist.tick_once()
+        assert first is not None
+        assert strategist.latest_intent().target_speed_kmh == 60
+
+        second = await strategist.tick_once()
+        assert second is None
+        # latest_intent must still be the previously good one
+        assert strategist.latest_intent().target_speed_kmh == 60
+
+    @pytest.mark.asyncio
+    async def test_swallows_generate_fn_exceptions(self):
+        async def boom(_prompt: str) -> str:
+            raise RuntimeError("model exploded")
+
+        strategist = LLMStrategist(boom)
+        strategist.set_observation("obs")
+
+        result = await strategist.tick_once()
+        assert result is None
+        assert strategist.latest_intent() is None
+
+    @pytest.mark.asyncio
+    async def test_timeout_does_not_raise(self):
+        async def slow(_prompt: str) -> str:
+            await asyncio.sleep(1.0)
+            return "{}"
+
+        strategist = LLMStrategist(slow, timeout_s=0.05)
+        strategist.set_observation("obs")
+
+        result = await strategist.tick_once()
+        assert result is None
+        assert strategist.latest_intent() is None
+
+    @pytest.mark.asyncio
+    async def test_timeout_preserves_previous_intent(self):
+        good = '{"target_speed_kmh": 50, "racing_line_offset_m": 0, "aggression": 0.5}'
+        call_count = {"n": 0}
+
+        async def first_fast_then_slow(_prompt: str) -> str:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return good
+            await asyncio.sleep(1.0)
+            return "{}"
+
+        strategist = LLMStrategist(first_fast_then_slow, timeout_s=0.05)
+        strategist.set_observation("obs")
+
+        await strategist.tick_once()
+        assert strategist.latest_intent().target_speed_kmh == 50
+
+        await strategist.tick_once()  # this one times out
+        assert strategist.latest_intent().target_speed_kmh == 50
+
+
+# ===== LLMStrategist start/stop lifecycle =====
+
+
+class TestStrategistLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_runs_loop_in_background(self):
+        good = '{"target_speed_kmh": 70, "racing_line_offset_m": 0, "aggression": 0.5}'
+        strategist = LLMStrategist(
+            _make_fake_generate([good]),
+            tick_interval_s=0.01,
+        )
+        strategist.set_observation("obs")
+
+        await strategist.start()
+        # Give the loop a couple of ticks
+        await asyncio.sleep(0.05)
+        await strategist.stop()
+
+        assert strategist.latest_intent() is not None
+        assert strategist.latest_intent().target_speed_kmh == 70
+
+    @pytest.mark.asyncio
+    async def test_stop_is_idempotent(self):
+        strategist = LLMStrategist(_make_fake_generate(["{}"]), tick_interval_s=0.01)
+        await strategist.start()
+        await strategist.stop()
+        await strategist.stop()  # second call must not raise
+
+    @pytest.mark.asyncio
+    async def test_start_twice_is_noop(self):
+        strategist = LLMStrategist(_make_fake_generate(["{}"]), tick_interval_s=0.01)
+        await strategist.start()
+        task_first = strategist._task
+        await strategist.start()
+        task_second = strategist._task
+        assert task_first is task_second
+        await strategist.stop()

--- a/backend/tests/test_mlx_runtime.py
+++ b/backend/tests/test_mlx_runtime.py
@@ -1,0 +1,47 @@
+"""MLX-gated integration tests for the LLM strategist (issue #152).
+
+These tests load the real model. They are skipped automatically when
+MLX is not installed (i.e. on CI or non-Apple-Silicon machines), so
+the main test suite remains fast and portable.
+
+Run locally with:
+    cd backend && ./venv/bin/python -m pytest tests/test_mlx_runtime.py -v
+
+Override the default model with MLX_MODEL_PATH; e.g. a smaller model
+for faster iteration.
+"""
+
+import pytest
+
+from app.agents.llm_strategist import LLMStrategist
+from app.agents.mlx_runtime import is_available
+
+pytestmark = pytest.mark.skipif(
+    not is_available(),
+    reason="MLX not installed (optional dependency, Apple Silicon only)",
+)
+
+
+@pytest.mark.asyncio
+async def test_real_mlx_call_returns_parseable_intent():
+    """End-to-end: load model, prompt it, parse an Intent.
+
+    Slow: loads the full model on first call. We use a constrained
+    observation so even a small model is likely to produce valid JSON.
+    """
+    from app.agents.mlx_runtime import get_mlx_generate_fn
+
+    strategist = LLMStrategist(get_mlx_generate_fn(), timeout_s=30.0)
+    strategist.set_observation(
+        "speed: 50 km/h, next checkpoint: 80m straight ahead, "
+        "surface: asphalt, no opponents"
+    )
+
+    intent = await strategist.tick_once()
+    # The model may occasionally fail to produce valid JSON; we accept
+    # either a parsed Intent or None (per the strategist's contract).
+    # The strong assertion: it must NOT raise.
+    if intent is not None:
+        assert 0 <= intent.target_speed_kmh <= 400
+        assert -20 <= intent.racing_line_offset_m <= 20
+        assert 0 <= intent.aggression <= 1


### PR DESCRIPTION
## Summary

First user-story in the M7 LLM-agent epic (#151). Scaffolds the trusted-code side of the two-tier agent — schema, async strategist, optional MLX runtime — so #153 (controller), #155 (engine integration), and #156 (UI) can build on stable interfaces.

Closes #152. Part of #151.

## What's in

New module `backend/app/agents/`:
- **`intent.py`** — Pydantic `Intent` schema (`target_speed_kmh`, `racing_line_offset_m`, `aggression`) with validation bounds. Pure data, no runtime deps.
- **`llm_strategist.py`** — async strategist around a **dependency-injected `generate_fn`** (`async (prompt: str) -> str`). Exposes `start` / `stop` / `tick_once` / `set_observation` / `latest_intent`. JSON parsing tolerates code fences and surrounding noise. On parse error, validation error, timeout, or `generate_fn` exception, the previous good Intent is preserved.
- **`mlx_runtime.py`** — lazily-loaded singleton wrapping `mlx-lm`. Guarded import so the package stays importable without MLX. `is_available()` lets tests gate themselves.

Dependencies:
- `requirements.txt` unchanged — MLX stays optional.
- New `requirements-agents.txt` lists `mlx` + `mlx-lm` for Apple-Silicon users who want to actually run agents.

## Why DI for `generate_fn`

Every interesting behavior (timeout, parsing, last-good fallback, async lifecycle, exception swallowing) is exercised with synchronous fake `generate_fn`s. Tests run in 0.2s without MLX. The real MLX path is exercised by one `skipif`-gated integration test.

## Tests

- **`test_llm_strategist.py`** — 22 unit tests:
  - Intent bounds (negative speed / out-of-range aggression / out-of-range offset all rejected)
  - Parser robustness: clean JSON, JSON inside code fences, empty string, no braces, malformed JSON, missing field, out-of-range value
  - `tick_once` semantics: no-observation path, success, parse-failure preserves last good, generate_fn exception swallowed, timeout doesn't raise, timeout preserves previous Intent
  - Lifecycle: `start` runs loop in background, `stop` idempotent, double `start` is no-op
- **`test_mlx_runtime.py`** — 1 MLX-gated end-to-end test (`skipif` when MLX is missing); asserts the strategist contract holds with a real model.

Full backend suite: **317 passed, 1 skipped** (was 295 before; +22 new).

## Test plan

- [x] `cd backend && ./venv/bin/python -m pytest tests/ -v` — 317 passed, 1 skipped
- [x] Acceptance criteria from #152:
  - [x] `pip install -r requirements.txt` works without MLX (MLX in separate file)
  - [x] `LLMStrategist` exposes async lifecycle + synchronous `latest_intent`
  - [x] Malformed JSON caught; `latest_intent` returns last good value
  - [x] Per-call timeout (2s default) drops the tick without raising
  - [x] MLX integration test marked `skipif`

## Manual verification

No UI in this PR — purely backend scaffolding consumed by downstream issues. Tests are the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)