### PR TITLE
feat: add observation formatter for LLM strategist (#153)

### DIFF
--- a/backend/app/agents/__init__.py
+++ b/backend/app/agents/__init__.py
@@ -13,5 +13,6 @@ Public API:
 
 from app.agents.intent import Intent
 from app.agents.llm_strategist import LLMStrategist
+from app.agents.observation import format_observation
 
-__all__ = ["Intent", "LLMStrategist"]
+__all__ = ["Intent", "LLMStrategist", "format_observation"]

--- a/backend/app/agents/observation.py
+++ b/backend/app/agents/observation.py
@@ -1,0 +1,155 @@
+"""Compact text observation for the LLM strategist (issue #153).
+
+Translates the existing per-car ``BotGameState`` (already produced by
+the bot_runtime for sandboxed Python bots) into a fixed-shape text
+prompt fragment suitable for a small LLM.
+
+Design notes (worth knowing before changing this file):
+
+- **Compact and stable in length.** The strategist's prompt size must
+  be predictable, so we always emit exactly 3 checkpoint slots and
+  exactly 2 opponent slots (filling with "none" when fewer are
+  available). Adding fields is fine; making fields variable in count
+  is not — it changes the model's effective context budget mid-race.
+
+- **Vector state only.** No images, no raycast lists. A 1.5B model
+  cannot reason about 7 raycast floats usefully at 1Hz; if we ever
+  want raycast-conditioned planning, that's a different observation
+  channel for a different model.
+
+- **Bearings are degrees, signed, relative to the car's heading.**
+  Positive = right (clockwise), negative = left, range (-180, 180].
+  This matches how humans describe relative direction ("turn 30° right").
+
+- **Speeds are km/h.** Distances are metres. These are the units a
+  driver would speak in.
+
+Example output::
+
+    speed: 80 km/h
+    heading: 45 deg
+    surface: gravel
+    off_track: no
+    edge_left: 5.2 m
+    edge_right: 4.8 m
+    checkpoint[1]: dist=120 m, bearing=15 deg
+    checkpoint[2]: dist=180 m, bearing=-30 deg
+    checkpoint[3]: dist=240 m, bearing=20 deg
+    opponent[1]: dist=45 m, bearing=-90 deg, rel_speed=10 km/h
+    opponent[2]: none
+"""
+
+from __future__ import annotations
+
+import math
+from typing import List, Tuple
+
+from app.bot_runtime.types import BotGameState, BotOpponent
+
+
+_NUM_CHECKPOINT_SLOTS = 3
+_NUM_OPPONENT_SLOTS = 2
+
+_MS_TO_KMH = 3.6
+
+
+def format_observation(state: BotGameState) -> str:
+    """Render a BotGameState as a compact text observation.
+
+    Pure function. Stable line count regardless of how many checkpoints
+    remain or opponents are visible.
+    """
+    lines: List[str] = []
+
+    speed_kmh = state.car.speed * _MS_TO_KMH
+    heading_deg = _wrap_signed_deg(math.degrees(state.car.heading))
+
+    lines.append(f"speed: {speed_kmh:.0f} km/h")
+    lines.append(f"heading: {heading_deg:.0f} deg")
+    lines.append(f"surface: {state.car.current_surface}")
+    lines.append(f"off_track: {'yes' if state.car.off_track else 'no'}")
+    lines.append(f"edge_left: {state.track.distance_to_boundary_left:.1f} m")
+    lines.append(f"edge_right: {state.track.distance_to_boundary_right:.1f} m")
+
+    for idx, line in enumerate(_format_checkpoints(state), start=1):
+        lines.append(f"checkpoint[{idx}]: {line}")
+
+    for idx, line in enumerate(_format_opponents(state.opponents), start=1):
+        lines.append(f"opponent[{idx}]: {line}")
+
+    return "\n".join(lines)
+
+
+def _format_checkpoints(state: BotGameState) -> List[str]:
+    """Return exactly _NUM_CHECKPOINT_SLOTS lines describing upcoming checkpoints."""
+    checkpoints = state.track.checkpoints
+    next_idx = state.track.next_checkpoint
+    car_x, car_y = state.car.position
+    heading_rad = state.car.heading
+
+    out: List[str] = []
+    for offset in range(_NUM_CHECKPOINT_SLOTS):
+        target = next_idx + offset
+        if target >= len(checkpoints):
+            out.append("none")
+            continue
+        cx, cy = checkpoints[target]
+        dist, bearing_deg = _polar_relative_to(car_x, car_y, heading_rad, cx, cy)
+        out.append(f"dist={dist:.0f} m, bearing={bearing_deg:.0f} deg")
+    return out
+
+
+def _format_opponents(opponents: List[BotOpponent]) -> List[str]:
+    """Return exactly _NUM_OPPONENT_SLOTS lines for the nearest opponents.
+
+    We trust ``BotOpponent.distance`` and ``BotOpponent.relative_angle``
+    (already car-relative) but compute relative speed ourselves to keep
+    the formatter self-contained.
+    """
+    nearest = sorted(opponents, key=lambda o: o.distance)[:_NUM_OPPONENT_SLOTS]
+
+    out: List[str] = []
+    for opp in nearest:
+        bearing_deg = _wrap_signed_deg(math.degrees(opp.relative_angle))
+        rel_speed_kmh = math.hypot(opp.velocity[0], opp.velocity[1]) * _MS_TO_KMH
+        out.append(
+            f"dist={opp.distance:.0f} m, bearing={bearing_deg:.0f} deg, "
+            f"rel_speed={rel_speed_kmh:.0f} km/h"
+        )
+    # Pad with "none" so total slot count is fixed
+    while len(out) < _NUM_OPPONENT_SLOTS:
+        out.append("none")
+    return out
+
+
+def _polar_relative_to(
+    car_x: float,
+    car_y: float,
+    car_heading_rad: float,
+    target_x: float,
+    target_y: float,
+) -> Tuple[float, float]:
+    """Return (distance_m, bearing_deg) of (target_x, target_y) seen from the car.
+
+    Bearing is signed degrees, positive = right of heading (clockwise),
+    chosen to match driver intuition ("turn right" = positive). Because
+    the game uses standard math y-up coordinates (BotCarState heading
+    0 = +x, π/2 = +y), atan2 produces a counter-clockwise angle from
+    +x, so we negate the relative angle to flip the rotation direction.
+    """
+    dx = target_x - car_x
+    dy = target_y - car_y
+    dist = math.hypot(dx, dy)
+    absolute_angle = math.atan2(dy, dx)
+    relative_rad = car_heading_rad - absolute_angle  # flip: CCW math -> CW bearing
+    bearing_deg = _wrap_signed_deg(math.degrees(relative_rad))
+    return dist, bearing_deg
+
+
+def _wrap_signed_deg(deg: float) -> float:
+    """Wrap an angle in degrees to (-180, 180]."""
+    wrapped = (deg + 180.0) % 360.0 - 180.0
+    # Python's mod yields exact -180 for 180; nudge to the open convention.
+    if wrapped == -180.0:
+        return 180.0
+    return wrapped

--- a/backend/tests/test_observation.py
+++ b/backend/tests/test_observation.py
@@ -1,0 +1,296 @@
+"""Unit tests for the observation formatter (issue #153).
+
+The formatter is the single most iterated-on surface in the LLM agent
+system. These tests pin down the format (golden output), the bearing
+sign convention (driver-intuitive: right = positive), unit conversions,
+solo-race behaviour, opponent ordering, and the fixed-slot guarantee
+that keeps prompt size stable.
+"""
+
+import math
+from typing import List, Optional, Tuple
+
+import pytest
+
+from app.agents.observation import (
+    _polar_relative_to,
+    _wrap_signed_deg,
+    format_observation,
+)
+from app.bot_runtime.types import (
+    BotCarState,
+    BotGameState,
+    BotOpponent,
+    BotRaceState,
+    BotRaycast,
+    BotTrackState,
+)
+
+
+# ===== Helpers =====
+
+
+def _car(
+    position: Tuple[float, float] = (0.0, 0.0),
+    heading: float = 0.0,
+    speed: float = 0.0,
+    surface: str = "asphalt",
+    off_track: bool = False,
+) -> BotCarState:
+    return BotCarState(
+        position=position,
+        heading=heading,
+        speed=speed,
+        velocity=(speed * math.cos(heading), speed * math.sin(heading)),
+        angular_velocity=0.0,
+        health=100.0,
+        nitro_charges=3,
+        nitro_active=False,
+        current_surface=surface,
+        off_track=off_track,
+    )
+
+
+def _track(
+    checkpoints: Optional[List[Tuple[float, float]]] = None,
+    next_checkpoint: int = 0,
+    edge_left: float = 5.0,
+    edge_right: float = 5.0,
+) -> BotTrackState:
+    return BotTrackState(
+        checkpoints=checkpoints if checkpoints is not None else [],
+        next_checkpoint=next_checkpoint,
+        distance_to_boundary_left=edge_left,
+        distance_to_boundary_right=edge_right,
+        upcoming_surface="asphalt",
+        upcoming_turn="straight",
+        turn_sharpness=0.0,
+    )
+
+
+def _opponent(
+    position: Tuple[float, float],
+    velocity: Tuple[float, float] = (0.0, 0.0),
+    heading: float = 0.0,
+    distance: float = 0.0,
+    relative_angle: float = 0.0,
+) -> BotOpponent:
+    return BotOpponent(
+        position=position,
+        velocity=velocity,
+        heading=heading,
+        distance=distance,
+        relative_angle=relative_angle,
+    )
+
+
+def _state(
+    car: Optional[BotCarState] = None,
+    track: Optional[BotTrackState] = None,
+    opponents: Optional[List[BotOpponent]] = None,
+    rays: Optional[List[BotRaycast]] = None,
+) -> BotGameState:
+    return BotGameState(
+        car=car if car is not None else _car(),
+        track=track if track is not None else _track(),
+        rays=rays if rays is not None else [],
+        opponents=opponents if opponents is not None else [],
+        race=BotRaceState(
+            current_checkpoint=0,
+            total_checkpoints=10,
+            position=1,
+            total_cars=1,
+            elapsed_time=0.0,
+            distance_to_finish=100.0,
+        ),
+    )
+
+
+# ===== Bearing-sign convention (the part future-me must not get wrong) =====
+
+
+class TestBearingConvention:
+    """Lock down positive = right (clockwise) from the car's heading."""
+
+    def test_target_directly_ahead_is_zero_bearing(self):
+        # Car at origin facing +x; target on +x axis.
+        _, bearing = _polar_relative_to(0, 0, 0.0, 50.0, 0.0)
+        assert bearing == pytest.approx(0.0, abs=1e-6)
+
+    def test_target_to_the_right_is_positive_bearing(self):
+        # Car at origin facing +x. In y-up math, "right of +x" is -y
+        # (below the x-axis). atan2(-1, 0) = -90° → after the sign flip
+        # the formatter must report +90°.
+        _, bearing = _polar_relative_to(0, 0, 0.0, 0.0, -50.0)
+        assert bearing == pytest.approx(90.0, abs=1e-6)
+
+    def test_target_to_the_left_is_negative_bearing(self):
+        # Target on +y axis (north in y-up). Car facing +x sees this as left.
+        _, bearing = _polar_relative_to(0, 0, 0.0, 0.0, 50.0)
+        assert bearing == pytest.approx(-90.0, abs=1e-6)
+
+    def test_target_behind_is_180(self):
+        _, bearing = _polar_relative_to(0, 0, 0.0, -50.0, 0.0)
+        # Either +180 or -180 is fine mathematically; we anchor to +180.
+        assert bearing == pytest.approx(180.0, abs=1e-6)
+
+
+class TestWrapSignedDeg:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (0.0, 0.0),
+            (90.0, 90.0),
+            (180.0, 180.0),
+            (-180.0, 180.0),
+            (181.0, -179.0),
+            (-181.0, 179.0),
+            (360.0, 0.0),
+            (450.0, 90.0),
+            (-450.0, -90.0),
+        ],
+    )
+    def test_wraps_to_open_minus_180_180(self, raw, expected):
+        assert _wrap_signed_deg(raw) == pytest.approx(expected, abs=1e-9)
+
+
+# ===== Format / golden output =====
+
+
+class TestFormatGolden:
+    def test_full_observation_matches_expected_lines(self):
+        state = _state(
+            car=_car(
+                position=(0.0, 0.0),
+                heading=0.0,
+                speed=20.0,  # m/s -> 72 km/h
+                surface="gravel",
+            ),
+            track=_track(
+                checkpoints=[(100.0, 0.0), (200.0, 0.0), (300.0, 0.0)],
+                next_checkpoint=0,
+                edge_left=5.2,
+                edge_right=4.8,
+            ),
+            opponents=[
+                _opponent(
+                    position=(50.0, 0.0),
+                    velocity=(10.0, 0.0),  # 36 km/h
+                    distance=50.0,
+                    relative_angle=0.0,
+                )
+            ],
+        )
+
+        out = format_observation(state)
+        lines = out.split("\n")
+        assert lines == [
+            "speed: 72 km/h",
+            "heading: 0 deg",
+            "surface: gravel",
+            "off_track: no",
+            "edge_left: 5.2 m",
+            "edge_right: 4.8 m",
+            "checkpoint[1]: dist=100 m, bearing=0 deg",
+            "checkpoint[2]: dist=200 m, bearing=0 deg",
+            "checkpoint[3]: dist=300 m, bearing=0 deg",
+            "opponent[1]: dist=50 m, bearing=0 deg, rel_speed=36 km/h",
+            "opponent[2]: none",
+        ]
+
+    def test_off_track_yes(self):
+        state = _state(car=_car(off_track=True))
+        assert "off_track: yes" in format_observation(state)
+
+    def test_surface_field_reflects_state(self):
+        for surface in ("asphalt", "gravel", "ice", "wet"):
+            out = format_observation(_state(car=_car(surface=surface)))
+            assert f"surface: {surface}" in out
+
+
+# ===== Stability: fixed slot count =====
+
+
+class TestSlotStability:
+    def test_solo_race_has_no_opponent_lines_but_padded_slots(self):
+        state = _state(opponents=[])
+        out = format_observation(state)
+        assert "opponent[1]: none" in out
+        assert "opponent[2]: none" in out
+        # Total line count fixed regardless of opponent count
+        assert len(out.split("\n")) == 11
+
+    def test_fewer_than_three_remaining_checkpoints_pads_with_none(self):
+        state = _state(
+            track=_track(checkpoints=[(100.0, 0.0)], next_checkpoint=0)
+        )
+        out = format_observation(state)
+        assert "checkpoint[1]: dist=100 m, bearing=0 deg" in out
+        assert "checkpoint[2]: none" in out
+        assert "checkpoint[3]: none" in out
+
+    def test_more_than_two_opponents_keeps_two_nearest(self):
+        opponents = [
+            _opponent(position=(100.0, 0.0), distance=100.0, relative_angle=0.0),
+            _opponent(position=(50.0, 0.0), distance=50.0, relative_angle=0.0),
+            _opponent(position=(20.0, 0.0), distance=20.0, relative_angle=0.0),
+        ]
+        out = format_observation(_state(opponents=opponents))
+        # Two nearest are distance 20 and 50; 100 must not appear in opponent slots
+        assert "opponent[1]: dist=20" in out
+        assert "opponent[2]: dist=50" in out
+        # The third opponent's distance shouldn't show up
+        assert "opponent[3]" not in out
+        assert "dist=100" not in out
+
+    def test_line_count_invariant_across_states(self):
+        a = format_observation(_state())
+        b = format_observation(
+            _state(
+                track=_track(checkpoints=[(1, 1), (2, 2)], next_checkpoint=0),
+                opponents=[
+                    _opponent((10, 0), distance=10, relative_angle=0),
+                    _opponent((20, 0), distance=20, relative_angle=0),
+                    _opponent((30, 0), distance=30, relative_angle=0),
+                ],
+            )
+        )
+        assert len(a.split("\n")) == len(b.split("\n"))
+
+
+# ===== Heading rotates bearings =====
+
+
+class TestHeadingRotatesBearings:
+    def test_rotating_car_heading_changes_checkpoint_bearing(self):
+        checkpoints = [(100.0, 0.0)]
+        # Car faces +x: checkpoint dead ahead.
+        state_a = _state(
+            car=_car(position=(0.0, 0.0), heading=0.0),
+            track=_track(checkpoints=checkpoints, next_checkpoint=0),
+        )
+        # Car now faces +y (left/north). The checkpoint at +x is to its right.
+        state_b = _state(
+            car=_car(position=(0.0, 0.0), heading=math.pi / 2),
+            track=_track(checkpoints=checkpoints, next_checkpoint=0),
+        )
+
+        assert "bearing=0 deg" in format_observation(state_a)
+        assert "bearing=90 deg" in format_observation(state_b)
+
+
+# ===== Pure / deterministic =====
+
+
+class TestPureFunction:
+    def test_same_state_yields_same_output(self):
+        state = _state()
+        assert format_observation(state) == format_observation(state)
+
+    def test_does_not_mutate_state(self):
+        opponents = [_opponent((50, 0), distance=50, relative_angle=0)]
+        state = _state(opponents=opponents)
+        before_ids = [id(o) for o in opponents]
+        _ = format_observation(state)
+        after_ids = [id(o) for o in opponents]
+        assert before_ids == after_ids  # same objects, same order


### PR DESCRIPTION
## Summary

Second M7 user-story. Pure function that turns `BotGameState` (already produced by the bot_runtime for sandboxed Python bots) into a compact text observation suitable for a 1.5B LLM.

Closes #153. Part of #151.

## Why reuse `BotGameState`

The bot_runtime already builds a per-car perspective view (sensor data) for sandboxed bots. Reusing it means:
- One source of truth for what a driver "sees"
- No new wiring through the engine
- Issue #155 (engine integration) just builds the BotGameState once per LLM tick and feeds it to the strategist's `set_observation`

## Design points (locked down by tests, worth re-reading before changing)

- **Compact and stable in length.** Always exactly 3 checkpoint slots and 2 opponent slots, padded with `none`. Prompt size stays predictable across the race — important for prompt cache hits later, and for the strategist's per-call timeout to remain meaningful.
- **Vector state only.** No raycasts. A 1.5B model would not exploit 7 raycast floats at 1Hz.
- **Driver-intuitive bearings.** Signed degrees, positive = right of heading (clockwise), in (-180, 180]. Game convention is y-up math (heading 0 = +x), so the implementation negates the CCW atan2 result to flip rotation direction. The sign convention is locked down by four explicit tests.
- **km/h for speed, metres for distance.**

Example output:
```
speed: 80 km/h
heading: 45 deg
surface: gravel
off_track: no
edge_left: 5.2 m
edge_right: 4.8 m
checkpoint[1]: dist=120 m, bearing=15 deg
checkpoint[2]: dist=180 m, bearing=-30 deg
checkpoint[3]: dist=240 m, bearing=20 deg
opponent[1]: dist=45 m, bearing=-90 deg, rel_speed=10 km/h
opponent[2]: none
```

## Tests

23 new unit tests (`backend/tests/test_observation.py`):

- **Bearing sign convention** — target ahead/right/left/behind all produce the expected sign. This is the part most likely to be silently wrong if someone refactors.
- **`_wrap_signed_deg`** — parameterised across boundary cases (0, ±180, ±360, 450, etc.)
- **Golden output** — full hand-crafted state matches expected line-by-line output
- **Surface and off_track** fields reflected
- **Slot stability** — solo race pads opponents, fewer than 3 remaining checkpoints pads with `none`, more than 2 opponents keeps the two nearest
- **Heading rotation** changes checkpoint bearings as expected
- **Pure / deterministic** — same input → same output, no mutation

Full backend suite: **340 passed, 1 skipped** (was 317; +23 new).

## Test plan

- [x] `cd backend && ./venv/bin/python -m pytest tests/test_observation.py -v` — 23 passed
- [x] `cd backend && ./venv/bin/python -m pytest tests/ -v` — 340 passed, 1 skipped (MLX)
- [x] Acceptance criteria from #153:
  - [x] Pure & deterministic given the same state
  - [x] Stable output length (no unbounded fields)
  - [x] Works with 0..N opponents (handles solo case)
  - [x] Format documented with worked example in module docstring

## Manual verification

No UI in this PR. Pure function; tests carry the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)