### PR TITLE
feat: add deterministic controller for LLM agent (#154)

### DIFF
--- a/backend/app/agents/__init__.py
+++ b/backend/app/agents/__init__.py
@@ -11,8 +11,15 @@ Public API:
     - MLXRuntime / get_mlx_generate_fn: optional MLX-backed generation
 """
 
+from app.agents.controller import Controller, ControlInputs
 from app.agents.intent import Intent
 from app.agents.llm_strategist import LLMStrategist
 from app.agents.observation import format_observation
 
-__all__ = ["Intent", "LLMStrategist", "format_observation"]
+__all__ = [
+    "Controller",
+    "ControlInputs",
+    "Intent",
+    "LLMStrategist",
+    "format_observation",
+]

--- a/backend/app/agents/controller.py
+++ b/backend/app/agents/controller.py
@@ -1,0 +1,203 @@
+"""Deterministic 20Hz controller for the LLM agent (issue #154).
+
+Consumes the latest :class:`Intent` produced by the strategist (#152)
+and the current :class:`BotGameState` and emits discrete control flags
+matching the engine's :class:`PlayerInput` shape.
+
+Two design decisions worth highlighting before changing this file:
+
+1. **Discrete output.** The engine accepts bool flags, not continuous
+   steer/throttle/brake. Pure-pursuit gives a continuous steering
+   angle which we threshold against a deadband to produce the bool
+   turn_left/turn_right flags. The same idea applies on the speed
+   axis (accelerate / brake / coast).
+
+2. **Hold-last-intent fallback.** If the strategist hasn't produced an
+   Intent yet, or returns None this tick, the controller reuses the
+   most recent valid Intent. With no Intent ever, it falls back to a
+   slow cruise along the next checkpoint direction. The controller
+   must never raise into the per-tick path.
+
+The lookahead point for steering is the *next checkpoint*, optionally
+shifted perpendicular to the car→checkpoint direction by
+``racing_line_offset_m`` (positive = right of track direction, matching
+the bearing convention used elsewhere in the agent code).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+from app.agents.intent import Intent
+from app.bot_runtime.types import BotGameState
+
+
+_MS_TO_KMH = 3.6
+
+# Hard ceilings independent of the Intent schema's own bounds.
+# Defensive only — the schema already clamps, but if someone constructs
+# an Intent by other means (or we change the schema later) this keeps
+# the controller from emitting nonsense.
+_MAX_TARGET_SPEED_KMH = 400.0
+_MAX_OFFSET_M = 20.0
+
+
+@dataclass(frozen=True)
+class ControlInputs:
+    """Discrete control flags matching the engine's PlayerInput shape."""
+
+    accelerate: bool = False
+    brake: bool = False
+    turn_left: bool = False
+    turn_right: bool = False
+    nitro: bool = False
+
+
+class Controller:
+    """Per-car deterministic controller. Hold one instance per LLM-driven car."""
+
+    def __init__(
+        self,
+        fallback_speed_kmh: float = 30.0,
+        base_steer_deadband_deg: float = 4.0,
+        base_speed_deadband_kmh: float = 4.0,
+    ) -> None:
+        self._fallback_speed_kmh = fallback_speed_kmh
+        self._base_steer_deadband_deg = base_steer_deadband_deg
+        self._base_speed_deadband_kmh = base_speed_deadband_kmh
+        self._last_intent: Optional[Intent] = None
+
+    def compute(self, intent: Optional[Intent], state: BotGameState) -> ControlInputs:
+        """Compute the next-tick control flags. Never raises."""
+        if intent is not None:
+            self._last_intent = intent
+        effective = intent if intent is not None else self._last_intent
+
+        if effective is None:
+            # No Intent has ever arrived — cruise slowly toward the next checkpoint.
+            return self._compute_from_target(
+                target_speed_kmh=self._fallback_speed_kmh,
+                racing_line_offset_m=0.0,
+                aggression=0.0,
+                state=state,
+            )
+
+        return self._compute_from_target(
+            target_speed_kmh=_clamp(effective.target_speed_kmh, 0.0, _MAX_TARGET_SPEED_KMH),
+            racing_line_offset_m=_clamp(effective.racing_line_offset_m, -_MAX_OFFSET_M, _MAX_OFFSET_M),
+            aggression=_clamp(effective.aggression, 0.0, 1.0),
+            state=state,
+        )
+
+    # ----- internals -----
+
+    def _compute_from_target(
+        self,
+        target_speed_kmh: float,
+        racing_line_offset_m: float,
+        aggression: float,
+        state: BotGameState,
+    ) -> ControlInputs:
+        steer = self._compute_steering(racing_line_offset_m, aggression, state)
+        accel, brake = self._compute_speed(target_speed_kmh, aggression, state)
+        return ControlInputs(
+            accelerate=accel,
+            brake=brake,
+            turn_left=steer == "left",
+            turn_right=steer == "right",
+        )
+
+    def _compute_steering(
+        self,
+        racing_line_offset_m: float,
+        aggression: float,
+        state: BotGameState,
+    ) -> str:
+        """Return 'left', 'right', or 'straight'."""
+        lookahead = self._lookahead_point(racing_line_offset_m, state)
+        if lookahead is None:
+            return "straight"
+
+        car_x, car_y = state.car.position
+        dx = lookahead[0] - car_x
+        dy = lookahead[1] - car_y
+        if dx == 0.0 and dy == 0.0:
+            return "straight"
+
+        absolute_angle = math.atan2(dy, dx)
+        # Bearing positive = right of heading (matches observation.py convention).
+        bearing_deg = math.degrees(state.car.heading - absolute_angle)
+        bearing_deg = _wrap_signed_deg(bearing_deg)
+
+        # Aggression tightens the deadband: higher aggression = quicker to turn.
+        deadband = self._base_steer_deadband_deg * (1.0 - 0.5 * aggression)
+        if bearing_deg > deadband:
+            return "right"
+        if bearing_deg < -deadband:
+            return "left"
+        return "straight"
+
+    def _compute_speed(
+        self,
+        target_speed_kmh: float,
+        aggression: float,
+        state: BotGameState,
+    ) -> tuple:
+        """Return (accelerate, brake) bool pair."""
+        current_kmh = state.car.speed * _MS_TO_KMH
+        deadband = self._base_speed_deadband_kmh * (1.0 - 0.5 * aggression)
+        delta = target_speed_kmh - current_kmh
+
+        if delta > deadband:
+            return True, False
+        if delta < -deadband:
+            return False, True
+        return False, False
+
+    def _lookahead_point(
+        self,
+        racing_line_offset_m: float,
+        state: BotGameState,
+    ) -> Optional[tuple]:
+        """Lookahead = next checkpoint + perpendicular offset.
+
+        Returns None when no checkpoint is available (e.g. all passed),
+        which the caller treats as "go straight".
+        """
+        checkpoints = state.track.checkpoints
+        idx = state.track.next_checkpoint
+        if idx < 0 or idx >= len(checkpoints):
+            return None
+
+        cx, cy = checkpoints[idx]
+        car_x, car_y = state.car.position
+
+        # Track direction unit vector at the car (approximated as car → checkpoint).
+        dx = cx - car_x
+        dy = cy - car_y
+        norm = math.hypot(dx, dy)
+        if norm == 0.0:
+            return cx, cy
+        ux, uy = dx / norm, dy / norm
+
+        # Right perpendicular in y-up math: rotate (ux, uy) by -90° clockwise.
+        # rot_-90(u) = (uy, -ux). Positive offset shifts to the right of track dir.
+        px, py = uy, -ux
+        return (cx + racing_line_offset_m * px, cy + racing_line_offset_m * py)
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    if value < lo:
+        return lo
+    if value > hi:
+        return hi
+    return value
+
+
+def _wrap_signed_deg(deg: float) -> float:
+    wrapped = (deg + 180.0) % 360.0 - 180.0
+    if wrapped == -180.0:
+        return 180.0
+    return wrapped

--- a/backend/tests/test_controller.py
+++ b/backend/tests/test_controller.py
@@ -1,0 +1,269 @@
+"""Unit tests for the deterministic controller (issue #154).
+
+The controller is the only thing the engine sees at the 20Hz tick, so
+its contract is tight: never raise, always emit something sensible, be
+deterministic, and degrade gracefully when the strategist is silent or
+the track data is missing.
+"""
+
+import math
+from typing import List, Optional, Tuple
+
+import pytest
+
+from app.agents.controller import Controller, ControlInputs
+from app.agents.intent import Intent
+from app.bot_runtime.types import (
+    BotCarState,
+    BotGameState,
+    BotRaceState,
+    BotTrackState,
+)
+
+
+# ===== Helpers =====
+
+
+def _car(
+    position: Tuple[float, float] = (0.0, 0.0),
+    heading: float = 0.0,
+    speed_ms: float = 0.0,
+) -> BotCarState:
+    return BotCarState(
+        position=position,
+        heading=heading,
+        speed=speed_ms,
+        velocity=(speed_ms * math.cos(heading), speed_ms * math.sin(heading)),
+        angular_velocity=0.0,
+        health=100.0,
+        nitro_charges=3,
+        nitro_active=False,
+        current_surface="asphalt",
+        off_track=False,
+    )
+
+
+def _state(
+    car: Optional[BotCarState] = None,
+    checkpoints: Optional[List[Tuple[float, float]]] = None,
+    next_checkpoint: int = 0,
+) -> BotGameState:
+    return BotGameState(
+        car=car if car is not None else _car(),
+        track=BotTrackState(
+            checkpoints=checkpoints if checkpoints is not None else [(100.0, 0.0)],
+            next_checkpoint=next_checkpoint,
+            distance_to_boundary_left=5.0,
+            distance_to_boundary_right=5.0,
+            upcoming_surface="asphalt",
+            upcoming_turn="straight",
+            turn_sharpness=0.0,
+        ),
+        rays=[],
+        opponents=[],
+        race=BotRaceState(
+            current_checkpoint=0,
+            total_checkpoints=10,
+            position=1,
+            total_cars=1,
+            elapsed_time=0.0,
+            distance_to_finish=100.0,
+        ),
+    )
+
+
+def _intent(
+    target_speed_kmh: float = 80.0,
+    racing_line_offset_m: float = 0.0,
+    aggression: float = 0.5,
+) -> Intent:
+    return Intent(
+        target_speed_kmh=target_speed_kmh,
+        racing_line_offset_m=racing_line_offset_m,
+        aggression=aggression,
+    )
+
+
+# ===== Steering =====
+
+
+class TestSteering:
+    def test_checkpoint_dead_ahead_no_turn(self):
+        ctrl = Controller()
+        state = _state(
+            car=_car(position=(0.0, 0.0), heading=0.0),
+            checkpoints=[(100.0, 0.0)],
+        )
+        out = ctrl.compute(_intent(), state)
+        assert not out.turn_left
+        assert not out.turn_right
+
+    def test_checkpoint_to_the_left_steers_left(self):
+        # Car facing +x, checkpoint at (0, 100) -> in y-up math that's "above";
+        # bearing convention says +y is to the LEFT of a +x-facing driver.
+        ctrl = Controller()
+        state = _state(
+            car=_car(position=(0.0, 0.0), heading=0.0),
+            checkpoints=[(0.0, 100.0)],
+        )
+        out = ctrl.compute(_intent(), state)
+        assert out.turn_left and not out.turn_right
+
+    def test_checkpoint_to_the_right_steers_right(self):
+        ctrl = Controller()
+        state = _state(
+            car=_car(position=(0.0, 0.0), heading=0.0),
+            checkpoints=[(0.0, -100.0)],
+        )
+        out = ctrl.compute(_intent(), state)
+        assert out.turn_right and not out.turn_left
+
+    def test_racing_line_offset_shifts_lookahead_across_track(self):
+        # Both car and checkpoint on the +x axis; with zero offset, no turn.
+        # A positive offset shifts the lookahead to the right of track
+        # direction (which is +x), i.e. toward -y → the car should turn right.
+        ctrl_a = Controller()
+        ctrl_b = Controller()
+        state = _state(
+            car=_car(position=(0.0, 0.0), heading=0.0),
+            checkpoints=[(100.0, 0.0)],
+        )
+        no_offset = ctrl_a.compute(_intent(racing_line_offset_m=0.0), state)
+        with_offset = ctrl_b.compute(_intent(racing_line_offset_m=10.0), state)
+
+        assert not no_offset.turn_left and not no_offset.turn_right
+        assert with_offset.turn_right and not with_offset.turn_left
+
+    def test_negative_offset_steers_left(self):
+        ctrl = Controller()
+        state = _state(
+            car=_car(position=(0.0, 0.0), heading=0.0),
+            checkpoints=[(100.0, 0.0)],
+        )
+        out = ctrl.compute(_intent(racing_line_offset_m=-10.0), state)
+        assert out.turn_left and not out.turn_right
+
+    def test_no_checkpoint_does_not_turn(self):
+        ctrl = Controller()
+        state = _state(
+            car=_car(position=(0.0, 0.0), heading=0.0),
+            checkpoints=[],
+            next_checkpoint=0,
+        )
+        out = ctrl.compute(_intent(), state)
+        assert not out.turn_left and not out.turn_right
+
+
+# ===== Speed control =====
+
+
+class TestSpeed:
+    def test_below_target_accelerates(self):
+        ctrl = Controller()
+        state = _state(car=_car(speed_ms=10.0))  # 36 km/h
+        out = ctrl.compute(_intent(target_speed_kmh=80.0), state)
+        assert out.accelerate and not out.brake
+
+    def test_above_target_brakes(self):
+        ctrl = Controller()
+        state = _state(car=_car(speed_ms=30.0))  # 108 km/h
+        out = ctrl.compute(_intent(target_speed_kmh=50.0), state)
+        assert out.brake and not out.accelerate
+
+    def test_within_deadband_coasts(self):
+        ctrl = Controller()
+        # Aggression 0 → wider deadband (4 km/h). 80 km/h ± 3 km/h is coast.
+        state = _state(car=_car(speed_ms=80.0 / 3.6))
+        out = ctrl.compute(_intent(target_speed_kmh=80.0, aggression=0.0), state)
+        assert not out.accelerate and not out.brake
+
+    def test_target_speed_zero_brakes_when_moving(self):
+        ctrl = Controller()
+        state = _state(car=_car(speed_ms=20.0))
+        out = ctrl.compute(_intent(target_speed_kmh=0.0), state)
+        assert out.brake
+
+
+# ===== Fallback behaviour =====
+
+
+class TestFallback:
+    def test_none_intent_with_no_history_does_not_raise(self):
+        ctrl = Controller()
+        state = _state(car=_car(speed_ms=0.0))
+        out = ctrl.compute(None, state)
+        # Stationary + fallback cruise speed > 0 → should accelerate
+        assert isinstance(out, ControlInputs)
+        assert out.accelerate
+
+    def test_none_intent_holds_last_intent(self):
+        ctrl = Controller()
+        state = _state(car=_car(speed_ms=0.0))
+        first = ctrl.compute(_intent(target_speed_kmh=100.0), state)
+        held = ctrl.compute(None, state)
+        # Both ticks see speed 0; both should accelerate toward 100 km/h
+        assert first.accelerate == held.accelerate == True
+
+    def test_intent_replaces_held_intent(self):
+        ctrl = Controller()
+        state = _state(car=_car(speed_ms=30.0))  # 108 km/h
+        # Hold an intent that says target=100 → at 108, would brake
+        first = ctrl.compute(_intent(target_speed_kmh=100.0), state)
+        assert first.brake
+        # Now strategist returns a new intent with target=150 → should accelerate
+        new = ctrl.compute(_intent(target_speed_kmh=150.0), state)
+        assert new.accelerate and not new.brake
+
+
+# ===== Robustness =====
+
+
+class TestRobustness:
+    def test_extreme_intent_does_not_raise(self):
+        ctrl = Controller()
+        state = _state()
+        # Intent schema already clamps; we just verify the controller
+        # tolerates the schema's bounds without raising.
+        out = ctrl.compute(
+            Intent(target_speed_kmh=400.0, racing_line_offset_m=20.0, aggression=1.0),
+            state,
+        )
+        assert isinstance(out, ControlInputs)
+
+    def test_deterministic_given_same_inputs(self):
+        ctrl_a = Controller()
+        ctrl_b = Controller()
+        state = _state(
+            car=_car(position=(10.0, 5.0), heading=0.3, speed_ms=15.0),
+            checkpoints=[(100.0, 30.0), (200.0, 60.0)],
+            next_checkpoint=0,
+        )
+        intent = _intent(target_speed_kmh=90.0, racing_line_offset_m=2.0, aggression=0.4)
+        assert ctrl_a.compute(intent, state) == ctrl_b.compute(intent, state)
+
+    def test_aggression_one_or_zero_does_not_crash(self):
+        ctrl = Controller()
+        state = _state(car=_car(speed_ms=10.0))
+        for aggr in (0.0, 1.0):
+            out = ctrl.compute(_intent(aggression=aggr), state)
+            assert isinstance(out, ControlInputs)
+
+    def test_perf_under_1ms(self):
+        """Compute is synchronous and trivial; sanity-check the per-tick budget."""
+        import time
+
+        ctrl = Controller()
+        state = _state(
+            car=_car(position=(10.0, 5.0), heading=0.3, speed_ms=15.0),
+            checkpoints=[(100.0, 30.0), (200.0, 60.0), (300.0, 90.0)],
+        )
+        intent = _intent()
+
+        # Run 1000 iterations and average; absolute threshold is generous to
+        # avoid CI flakiness, the real budget is 50ms/tick at 20Hz.
+        start = time.perf_counter()
+        for _ in range(1000):
+            ctrl.compute(intent, state)
+        elapsed = time.perf_counter() - start
+        per_call_ms = (elapsed / 1000) * 1000
+        assert per_call_ms < 1.0, f"controller too slow: {per_call_ms:.3f} ms/call"


### PR DESCRIPTION
## Summary

Third M7 user-story. Synchronous 20Hz controller that turns the strategist's `Intent` into the engine's bool `PlayerInput` shape, completing the trio of primitives that #155 will glue together.

Closes #154. Part of #151.

## Design

- **Discrete output.** The engine accepts bool `accelerate` / `brake` / `turn_left` / `turn_right` flags, not continuous steering. Pure-pursuit gives a continuous bearing to the lookahead point which we threshold against an aggression-scaled deadband. Same idea on the speed axis (accelerate / brake / coast).
- **Lookahead point** = next checkpoint + perpendicular offset, where positive `racing_line_offset_m` shifts to the right of track direction (matches the observation bearing convention).
- **Hold-last-intent.** If the strategist returns `None` this tick, the controller reuses the most recent valid Intent. With no Intent ever, falls back to a slow cruise toward the next checkpoint.
- **Defensive clamping** on Intent values. The schema already bounds them, but the controller enforces hard ceilings so future schema changes or alternate constructions can't emit nonsense.
- **Never raises** into the per-tick path.

## Tests

17 new unit tests (`backend/tests/test_controller.py`):

- **Steering:** dead-ahead / left / right; racing-line offset shifts steering across the track; negative offset; missing checkpoint does not turn.
- **Speed:** below/above target / within deadband / `target=0` brakes.
- **Fallback:** `None` intent with no history doesn't raise; `None` intent holds last; fresh Intent replaces held Intent.
- **Robustness:** extreme intents tolerated; deterministic given same inputs; aggression 0 and 1 both stable; perf < 1ms/call over 1000 iterations.

Full backend suite: **357 passed, 1 skipped** (was 340; +17 new).

## Where this fits

After this merges, the three primitives are in place:

- #152 strategist (1Hz, async) — produces `Intent`
- #153 observation formatter — feeds it
- #154 controller (20Hz, sync) — consumes it

#155 is now unblocked: wire `LLMBot` (owns strategist + controller, calls `format_observation` per tick, exposes `get_inputs` to the engine) into the race engine as a new driver kind.

## Test plan

- [x] `cd backend && ./venv/bin/python -m pytest tests/test_controller.py -v` — 17 passed
- [x] `cd backend && ./venv/bin/python -m pytest tests/ -v` — 357 passed, 1 skipped (MLX)
- [x] Acceptance criteria from #154:
  - [x] <1ms per tick (verified by test_perf_under_1ms)
  - [x] Deterministic given same inputs
  - [x] Sane behaviour at extremes (target=0, large offset, aggression 0/1)
  - [x] No exceptions on `None` intent

## Manual verification

No UI in this PR. Pure-function tests carry the contract; engine integration is #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)